### PR TITLE
feat(online_data): Prioritize using online data to retrieve sticker display names

### DIFF
--- a/src/online_data/models.rs
+++ b/src/online_data/models.rs
@@ -77,4 +77,25 @@ impl OnlineGameData {
             .music_kits
             .get(&music_index.to_string())
     }
+
+    pub fn get_inventory_sticker(&self, sticker_index: u32) -> Option<&InventorySkinItem> {
+        self.inventory
+            .as_ref()?
+            .stickers
+            .get(&sticker_index.to_string())
+    }
+
+    pub fn get_inventory_graffiti(&self, graffiti_index: u32) -> Option<&InventorySkinItem> {
+        self.inventory
+            .as_ref()?
+            .graffiti
+            .get(&graffiti_index.to_string())
+    }
+
+    pub fn get_inventory_keychain(&self, keychain_index: u32) -> Option<&InventorySkinItem> {
+        self.inventory
+            .as_ref()?
+            .keychains
+            .get(&keychain_index.to_string())
+    }
 }

--- a/src/online_data/provider.rs
+++ b/src/online_data/provider.rs
@@ -164,9 +164,22 @@ impl DataProvider {
 
         if let Some(sticker_index) = item.attributes.get(&ItemAttribute::Sticker0ID.id())
             && let Ok(sticker_id) = sticker_index.parse::<u32>()
-            && let Some(sticker_name) = self.get_sticker_kit_display_name(sticker_id)
         {
-            return format!("{} | {}", item_name, sticker_name);
+            match self {
+                DataProvider::Local(_, _) => {
+                    if let Some(sticker_name) = self.get_sticker_kit_display_name(sticker_id) {
+                        return format!("{} | {}", item_name, sticker_name);
+                    }
+                }
+                DataProvider::Online(data, _, _) => {
+                    if let Some(sticker) = data.get_inventory_sticker(sticker_id) {
+                        return sticker.name.clone();
+                    }
+                    if let Some(sticker_name) = self.get_sticker_kit_display_name(sticker_id) {
+                        return format!("{} | {}", item_name, sticker_name);
+                    }
+                }
+            }
         }
 
         item_name

--- a/src/online_data/provider.rs
+++ b/src/online_data/provider.rs
@@ -54,8 +54,10 @@ impl DataProvider {
             DataProvider::Local(items_game, translations) => {
                 items_game.get_sticker_kit_display_name(sticker_index, translations)
             }
-            DataProvider::Online(_data, items_game, translations) => {
-                // Force use local data for display name (online format incompatible)
+            DataProvider::Online(data, items_game, translations) => {
+                if let Some(sticker) = data.get_inventory_sticker(sticker_index) {
+                    return Some(sticker.name.clone());
+                }
                 items_game.get_sticker_kit_display_name(sticker_index, translations)
             }
         }


### PR DESCRIPTION
When online data is available, prioritize retrieving sticker names from online data; otherwise, fall back to local data.

Also add a helper method for retrieving inventory items.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gt-610/csgo-gc-inventory-editor/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
