### PR TITLE
Add item attribute add/remove flows and fix localized UI text

### DIFF
--- a/csgo_gc/editor/languages/en-US.ftl
+++ b/csgo_gc/editor/languages/en-US.ftl
@@ -124,7 +124,10 @@ btn-save = Save
 btn-save-close = Save & Close
 btn-cancel = Cancel
 btn-delete = Delete Item
+btn-add-attribute = Add Attribute
+btn-delete-attribute = Delete
 btn-confirm = Confirm
+status-unsaved = Unsaved
 
 # Delete Confirmation Modal
 modal-delete-title = Delete Item
@@ -143,19 +146,25 @@ item-properties = Item Properties
 prop-index = Index
 prop-description = Description
 prop-value = Value
+actions = Actions
 
 # Select Window
 select-item = Select Item
+select-attribute = Select Attribute
 confirm = Confirm
 cancel = Cancel
 
 # Select Window Headers
 header-item-id = Item ID
 header-item-name = Item Name
+header-attribute-id = Attribute ID
+header-attribute-name = Attribute Name
 
 # Save Messages
 save-success = Inventory saved successfully
 save-failed = Failed to save inventory: { $error }
+inventory-error-title = Failed to Load Inventory
+inventory-error-help = Check the game directory settings or file permissions.
 
 # Item Attributes
 attr-6 = Skin Paint

--- a/csgo_gc/editor/languages/zh-Hans.ftl
+++ b/csgo_gc/editor/languages/zh-Hans.ftl
@@ -191,3 +191,12 @@ select-graffiti-tint = 选择涂鸦颜色
 header-graffiti-tint-id = 颜色 ID
 header-graffiti-tint-name = 颜色名称
 
+btn-add-attribute = 添加属性
+btn-delete-attribute = 删除
+actions = 操作
+select-attribute = 选择属性
+header-attribute-id = 属性 ID
+header-attribute-name = 属性名称
+status-unsaved = 未保存
+inventory-error-title = 读取库存错误
+inventory-error-help = 请检查游戏目录设置或文件权限

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@ use crate::config::{Config, ConfigLoader};
 use crate::core::GameDir;
 use crate::inventory::{
     AVAILABLE_ATTRIBUTES, GameTranslation, Inventory, InventoryLoader, ItemAttribute, ItemsGame,
-    ItemsGameLoader, LanguageFileParser, get_attribute_display_name,
+    ItemsGameLoader, LanguageFileParser, get_attribute_fluent_key,
 };
 use crate::online_data::{
     DataProvider, OnlineGameData, fetch_online_data_with_progress, load_cached_data,
@@ -10,6 +10,7 @@ use crate::online_data::{
 };
 use crate::settings::{Settings, Theme};
 use eframe::egui;
+use egui_i18n::tr;
 use egui_i18n::{load_translations_from_path, set_fallback, set_language};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -659,9 +660,10 @@ impl CsgoInventoryEditor {
             .iter()
             .filter(|attr_id| !current_attributes.contains_key(attr_id))
             .map(|attr_id| {
+                let fluent_key = get_attribute_fluent_key(*attr_id);
                 (
                     attr_id.to_string(),
-                    get_attribute_display_name(*attr_id, &self.translations),
+                    tr!(&fluent_key).to_string(),
                     attr_id.to_string(),
                     None,
                 )

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,8 @@
 use crate::config::{Config, ConfigLoader};
 use crate::core::GameDir;
 use crate::inventory::{
-    GameTranslation, Inventory, InventoryLoader, ItemAttribute, ItemsGame, ItemsGameLoader,
-    LanguageFileParser,
+    AVAILABLE_ATTRIBUTES, GameTranslation, Inventory, InventoryLoader, ItemAttribute, ItemsGame,
+    ItemsGameLoader, LanguageFileParser, get_attribute_display_name,
 };
 use crate::online_data::{
     DataProvider, OnlineGameData, fetch_online_data_with_progress, load_cached_data,
@@ -236,6 +236,7 @@ pub struct CsgoInventoryEditor {
     pub pending_music_def_select: Option<u64>,
     pub pending_sticker_kit_select: Option<(u64, u32)>,
     pub pending_graffiti_tint_select: Option<u64>,
+    pub pending_attribute_select: Option<u64>,
     pub settings: Settings,
     pub data_provider: DataProvider,
     pub online_data: Option<OnlineGameData>,
@@ -413,6 +414,7 @@ impl CsgoInventoryEditor {
             pending_music_def_select: None,
             pending_sticker_kit_select: None,
             pending_graffiti_tint_select: None,
+            pending_attribute_select: None,
             settings: settings.clone(),
             data_provider: DataProvider::Local(Box::new(items_game.clone()), translations.clone()),
             online_data: None,
@@ -636,6 +638,40 @@ impl CsgoInventoryEditor {
         self.items_game.create_graffiti_tint_select_list()
     }
 
+    pub fn create_missing_attribute_select_list(&self, item_id: u64) -> SelectWindowItems {
+        let current_attributes = self
+            .edit_item_states
+            .get(&item_id)
+            .map(|state| &state.attributes)
+            .or_else(|| {
+                self.inventory
+                    .items
+                    .iter()
+                    .find(|item| item.id == item_id)
+                    .map(|item| &item.attributes)
+            });
+
+        let Some(current_attributes) = current_attributes else {
+            return Vec::new();
+        };
+
+        let mut items: SelectWindowItems = AVAILABLE_ATTRIBUTES
+            .iter()
+            .filter(|attr_id| !current_attributes.contains_key(attr_id))
+            .map(|attr_id| {
+                (
+                    attr_id.to_string(),
+                    get_attribute_display_name(*attr_id, &self.translations),
+                    attr_id.to_string(),
+                    None,
+                )
+            })
+            .collect();
+
+        items.sort_by_key(|(id, _, _, _)| id.parse::<u32>().unwrap_or(0));
+        items
+    }
+
     pub fn create_skin_select_list_for_weapon(&self, weapon_id: u32) -> SelectWindowItems {
         self.data_provider
             .create_skin_select_list_for_weapon(weapon_id)
@@ -796,6 +832,7 @@ impl Default for CsgoInventoryEditor {
             pending_music_def_select: None,
             pending_sticker_kit_select: None,
             pending_graffiti_tint_select: None,
+            pending_attribute_select: None,
             settings: Settings::default(),
             data_provider: DataProvider::Local(Box::default(), GameTranslation::default()),
             online_data: None,

--- a/src/inventory/item_attribute.rs
+++ b/src/inventory/item_attribute.rs
@@ -225,3 +225,19 @@ pub fn get_attribute_value_display_name(
         _ => value.to_string(),
     }
 }
+
+pub fn get_attribute_default_value(attr_id: u32) -> &'static str {
+    match attr_id {
+        id if id == ItemAttribute::SkinPaintWear.id() => "0.001",
+        id if id == ItemAttribute::Sticker0Scale.id()
+            || id == ItemAttribute::Sticker1Scale.id()
+            || id == ItemAttribute::Sticker2Scale.id()
+            || id == ItemAttribute::Sticker3Scale.id()
+            || id == ItemAttribute::Sticker4Scale.id()
+            || id == ItemAttribute::Sticker5Scale.id() =>
+        {
+            "1"
+        }
+        _ => "0",
+    }
+}

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -8,8 +8,8 @@ pub mod parser;
 pub mod vdf;
 
 pub use item_attribute::{
-    AVAILABLE_ATTRIBUTES, ItemAttribute, get_attribute_display_name, get_attribute_fluent_key,
-    get_attribute_value_display_name,
+    AVAILABLE_ATTRIBUTES, ItemAttribute, get_attribute_default_value, get_attribute_display_name,
+    get_attribute_fluent_key, get_attribute_value_display_name,
 };
 pub use items_game::{
     GameTranslation, IGGraffitiTint, IGItem, IGMusicDef, IGPaintKit, IGQuality, IGRarity,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ pub mod settings;
 pub mod ui;
 
 use crate::app::{CsgoInventoryEditor, ItemTemplate, Page};
-use crate::inventory::ItemAttribute;
+use crate::inventory::{ItemAttribute, get_attribute_default_value};
 use eframe::egui;
 use egui_i18n::tr;
 
@@ -148,6 +148,20 @@ impl eframe::App for CsgoInventoryEditor {
                 items,
             );
             self.select_window_for_item = Some(inventory_id);
+        }
+
+        if let Some(inventory_id) = self.pending_attribute_select.take() {
+            self.pending_attribute_select = None;
+            let items = self.create_missing_attribute_select_list(inventory_id);
+            if !items.is_empty() {
+                self.open_select_window(
+                    tr!("select-attribute").to_string(),
+                    tr!("header-attribute-id").to_string(),
+                    tr!("header-attribute-name").to_string(),
+                    items,
+                );
+                self.select_window_for_item = Some(inventory_id);
+            }
         }
 
         if let Some(selected_idx) = self.select_window_selected {
@@ -305,6 +319,21 @@ impl eframe::App for CsgoInventoryEditor {
                     edit_state
                         .attributes
                         .insert(ItemAttribute::SprayColor.id(), tint_id_str.clone());
+                }
+                self.select_window_open = false;
+                self.select_window_selected = None;
+                self.select_window_for_item = None;
+            }
+
+            if self.select_window_title == tr!("select-attribute") {
+                if let Some(for_item_id) = self.select_window_for_item
+                    && let Some((attr_id_str, _, _, _)) = self.select_window_items.get(selected_idx)
+                    && let Ok(attr_id) = attr_id_str.parse::<u32>()
+                    && let Some(edit_state) = self.edit_item_states.get_mut(&for_item_id)
+                {
+                    edit_state
+                        .attributes
+                        .insert(attr_id, get_attribute_default_value(attr_id).to_string());
                 }
                 self.select_window_open = false;
                 self.select_window_selected = None;

--- a/src/ui/inventory_page.rs
+++ b/src/ui/inventory_page.rs
@@ -1,5 +1,6 @@
 use crate::app::CsgoInventoryEditor;
 use eframe::egui;
+use egui_i18n::tr;
 
 pub fn draw_inventory_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     if state.has_inventory_error() {
@@ -8,7 +9,7 @@ pub fn draw_inventory_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
                 ui.vertical_centered(|ui| {
                     ui.add_space(100.0);
                     ui.heading(
-                        egui::RichText::new("读取库存错误")
+                        egui::RichText::new(tr!("inventory-error-title"))
                             .size(24.0)
                             .color(egui::Color32::RED),
                     );
@@ -20,7 +21,7 @@ pub fn draw_inventory_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
                     );
                     ui.add_space(20.0);
                     ui.label(
-                        egui::RichText::new("请检查游戏目录设置或文件权限")
+                        egui::RichText::new(tr!("inventory-error-help"))
                             .size(14.0)
                             .color(egui::Color32::GRAY),
                     );

--- a/src/ui/item_detail.rs
+++ b/src/ui/item_detail.rs
@@ -276,7 +276,7 @@ pub fn draw_item_detail_windows(
                 let attr_table = TableBuilder::new(ui)
                     .id_salt(format!("attr_{}", item_id))
                     .striped(true)
-                    .resizable(true)
+                    .resizable(false)
                     .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
                     .column(Column::auto())
                     .column(Column::auto())

--- a/src/ui/item_detail.rs
+++ b/src/ui/item_detail.rs
@@ -1,5 +1,7 @@
 use crate::app::{CsgoInventoryEditor, EditItemState, ItemTemplate, SelectWindowItems};
-use crate::inventory::{ItemAttribute, get_attribute_fluent_key, get_attribute_value_display_name};
+use crate::inventory::{
+    AVAILABLE_ATTRIBUTES, ItemAttribute, get_attribute_fluent_key, get_attribute_value_display_name,
+};
 use eframe::egui;
 use egui_extras::{Column, TableBuilder};
 use egui_i18n::tr;
@@ -94,7 +96,7 @@ pub fn draw_item_detail_windows(
                     if has_unsaved_changes {
                         ui.add_space(20.0);
                         ui.label(
-                            egui::RichText::new("⚪未保存")
+                            egui::RichText::new(tr!("status-unsaved"))
                                 .color(egui::Color32::from_rgb(200, 150, 0))
                                 .size(14.0),
                         );
@@ -247,7 +249,24 @@ pub fn draw_item_detail_windows(
 
                 ui.separator();
 
-                let mut attr_vec: Vec<(u32, String)> = item
+                ui.horizontal(|ui| {
+                    let can_add_attribute = AVAILABLE_ATTRIBUTES
+                        .iter()
+                        .any(|attr_id| !edit_state.attributes.contains_key(attr_id));
+                    if ui
+                        .add_enabled(
+                            can_add_attribute,
+                            egui::Button::new(tr!("btn-add-attribute")),
+                        )
+                        .clicked()
+                    {
+                        state.pending_attribute_select = Some(item_id_for_edit);
+                    }
+                });
+
+                ui.add_space(8.0);
+
+                let mut attr_vec: Vec<(u32, String)> = edit_state
                     .attributes
                     .iter()
                     .map(|(k, v)| (*k, v.clone()))
@@ -262,6 +281,7 @@ pub fn draw_item_detail_windows(
                     .column(Column::auto())
                     .column(Column::auto())
                     .column(Column::remainder())
+                    .column(Column::auto())
                     .min_scrolled_height(150.0);
 
                 attr_table
@@ -274,6 +294,9 @@ pub fn draw_item_detail_windows(
                         });
                         header.col(|ui| {
                             ui.strong(tr!("prop-value"));
+                        });
+                        header.col(|ui| {
+                            ui.strong(tr!("actions"));
                         });
                     })
                     .body(|mut body| {
@@ -352,6 +375,11 @@ pub fn draw_item_detail_windows(
                                             .entry(*attr_id)
                                             .or_insert_with(|| edit_value.clone());
                                         ui.text_edit_singleline(value_mut);
+                                    }
+                                });
+                                row.col(|ui| {
+                                    if ui.button(tr!("btn-delete-attribute")).clicked() {
+                                        edit_state.attributes.remove(attr_id);
                                     }
                                 });
                             });


### PR DESCRIPTION
## Summary
- add attribute management in item detail windows, including selecting missing attributes and deleting existing ones
- add default values for newly inserted known attributes to avoid invalid initial states
- wire new attribute selection through the existing select-window flow and save path
- replace hardcoded status/error text with translation keys
- fix new English and Simplified Chinese localization entries for attribute actions and inventory error messaging

## Testing
- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo build`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gt-610/csgo-gc-inventory-editor/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
