### PR TITLE
Optimize inventory UI responsiveness and restore resizable dialogs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,23 @@
 use std::fs;
 use std::path::Path;
 
+fn should_copy_file(src: &Path, dst: &Path) -> bool {
+    let Ok(src_meta) = fs::metadata(src) else {
+        return false;
+    };
+
+    let Ok(dst_meta) = fs::metadata(dst) else {
+        return true;
+    };
+
+    src_meta.len() != dst_meta.len()
+        || src_meta
+            .modified()
+            .ok()
+            .zip(dst_meta.modified().ok())
+            .is_none_or(|(src_time, dst_time)| src_time > dst_time)
+}
+
 fn copy_dir_recursive(src: &Path, dst: &Path) {
     fs::create_dir_all(dst).expect("Failed to create directory");
 
@@ -11,7 +28,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path) {
 
         if src_path.is_dir() {
             copy_dir_recursive(&src_path, &dest_path);
-        } else {
+        } else if should_copy_file(&src_path, &dest_path) {
             fs::copy(&src_path, &dest_path)
                 .unwrap_or_else(|_| panic!("Failed to copy file: {:?}", src_path));
         }
@@ -31,12 +48,8 @@ fn main() {
 
     let src_csgo_gc = Path::new("csgo_gc");
     let target_csgo_gc = target_dir.join(&profile).join("csgo_gc");
-    let target_editor = target_csgo_gc.join("editor");
 
     if src_csgo_gc.exists() {
-        if target_editor.exists() {
-            fs::remove_dir_all(&target_editor).expect("Failed to remove existing editor directory");
-        }
         println!("cargo:warning=Copying csgo_gc to: {:?}", target_csgo_gc);
         copy_dir_recursive(src_csgo_gc, &target_csgo_gc);
     }

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,25 @@
 use std::fs;
 use std::path::Path;
 
+fn watch_dir_recursive(path: &Path) {
+    if !path.exists() {
+        return;
+    }
+
+    println!("cargo:rerun-if-changed={}", path.display());
+
+    for entry in fs::read_dir(path).expect("Failed to read directory") {
+        let entry = entry.expect("Failed to read entry");
+        let entry_path = entry.path();
+
+        if entry_path.is_dir() {
+            watch_dir_recursive(&entry_path);
+        } else {
+            println!("cargo:rerun-if-changed={}", entry_path.display());
+        }
+    }
+}
+
 fn should_copy_file(src: &Path, dst: &Path) -> bool {
     let Ok(src_meta) = fs::metadata(src) else {
         return false;
@@ -36,8 +55,6 @@ fn copy_dir_recursive(src: &Path, dst: &Path) {
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed=csgo_gc");
-
     let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
     let out_dir = std::env::var("OUT_DIR").unwrap();
 
@@ -50,7 +67,7 @@ fn main() {
     let target_csgo_gc = target_dir.join(&profile).join("csgo_gc");
 
     if src_csgo_gc.exists() {
-        println!("cargo:warning=Copying csgo_gc to: {:?}", target_csgo_gc);
+        watch_dir_recursive(src_csgo_gc);
         copy_dir_recursive(src_csgo_gc, &target_csgo_gc);
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -211,8 +211,8 @@ pub struct EditItemState {
 
 pub struct CsgoInventoryEditor {
     pub inventory: Inventory,
-    pub items_game: ItemsGame,
-    pub translations: GameTranslation,
+    pub items_game: Arc<ItemsGame>,
+    pub translations: Arc<GameTranslation>,
     pub selected_category: InventoryCategory,
     pub selected_subcategory: Option<String>,
     pub search_query: String,
@@ -246,7 +246,8 @@ pub struct CsgoInventoryEditor {
     pub current_page: Page,
     pub current_settings_page: SettingsPage,
     pub config: Config,
-    cached_sorted_inventory_ids: Vec<u64>,
+    cached_sorted_inventory_indices: Vec<usize>,
+    cached_item_indices_by_id: HashMap<u64, usize>,
     cached_items_count: usize,
     cached_item_display_names: RefCell<HashMap<u64, String>>,
     inventory_load_error: Option<String>,
@@ -387,10 +388,13 @@ impl CsgoInventoryEditor {
             Config::default()
         };
 
+        let items_game = Arc::new(items_game);
+        let translations = Arc::new(translations);
+
         let mut app = Self {
             inventory,
-            items_game: items_game.clone(),
-            translations: translations.clone(),
+            items_game: Arc::clone(&items_game),
+            translations: Arc::clone(&translations),
             selected_category: InventoryCategory::All,
             selected_subcategory: None,
             search_query: String::new(),
@@ -417,14 +421,18 @@ impl CsgoInventoryEditor {
             pending_graffiti_tint_select: None,
             pending_attribute_select: None,
             settings: settings.clone(),
-            data_provider: DataProvider::Local(Box::new(items_game.clone()), translations.clone()),
+            data_provider: DataProvider::Local {
+                items_game: Arc::clone(&items_game),
+                translations: Arc::clone(&translations),
+            },
             online_data: None,
             is_loading_online: false,
             online_data_receiver: None,
             current_page: Page::default(),
             current_settings_page: SettingsPage::default(),
             config,
-            cached_sorted_inventory_ids: Vec::new(),
+            cached_sorted_inventory_indices: Vec::new(),
+            cached_item_indices_by_id: HashMap::new(),
             cached_items_count: 0,
             cached_item_display_names: RefCell::new(HashMap::new()),
             inventory_load_error,
@@ -434,8 +442,11 @@ impl CsgoInventoryEditor {
         // Try to load online data cache on startup
         if let Some((data, timestamp)) = load_cached_data(&settings.language) {
             println!("[new] Online data cache found, loading...");
-            app.data_provider =
-                DataProvider::Online(Box::new(data.clone()), Box::new(items_game), translations);
+            app.data_provider = DataProvider::Online {
+                data: Arc::new(data.clone()),
+                items_game,
+                translations,
+            };
             app.online_data = Some(data);
             app.settings.last_online_update = Some(timestamp);
         }
@@ -467,10 +478,7 @@ impl CsgoInventoryEditor {
             if lang_file.exists() {
                 match LanguageFileParser::load(&lang_file) {
                     Ok(t) => {
-                        self.translations = t;
-                        if let Some(dp_translations) = self.data_provider.as_translations_mut() {
-                            *dp_translations = self.translations.clone();
-                        }
+                        self.translations = Arc::new(t);
                     }
                     Err(e) => eprintln!("Failed to load language file: {}", e),
                 }
@@ -481,24 +489,29 @@ impl CsgoInventoryEditor {
         self.cached_item_display_names.borrow_mut().clear();
 
         // Reload online data for the new language if currently using online mode
-        if matches!(self.data_provider, DataProvider::Online(_, _, _)) {
+        if matches!(self.data_provider, DataProvider::Online { .. }) {
             if let Some((data, timestamp)) = load_cached_data(language) {
-                self.data_provider = DataProvider::Online(
-                    Box::new(data.clone()),
-                    Box::new(self.items_game.clone()),
-                    self.translations.clone(),
-                );
+                self.data_provider = DataProvider::Online {
+                    data: Arc::new(data.clone()),
+                    items_game: Arc::clone(&self.items_game),
+                    translations: Arc::clone(&self.translations),
+                };
                 self.online_data = Some(data);
                 self.settings.last_online_update = Some(timestamp);
                 let _ = self.settings.save();
             } else {
                 // No cache for new language, fall back to local mode
-                self.data_provider = DataProvider::Local(
-                    Box::new(self.items_game.clone()),
-                    self.translations.clone(),
-                );
+                self.data_provider = DataProvider::Local {
+                    items_game: Arc::clone(&self.items_game),
+                    translations: Arc::clone(&self.translations),
+                };
                 self.online_data = None;
             }
+        } else {
+            self.data_provider = DataProvider::Local {
+                items_game: Arc::clone(&self.items_game),
+                translations: Arc::clone(&self.translations),
+            };
         }
     }
 
@@ -530,6 +543,7 @@ impl CsgoInventoryEditor {
                 .map_err(|e| e.to_string());
             if result.is_ok() {
                 self.cached_item_display_names.borrow_mut().clear();
+                self.cached_items_count = self.inventory.items.len();
             }
             result
         } else {
@@ -753,11 +767,11 @@ impl CsgoInventoryEditor {
                     }
                     self.settings.last_online_update = Some(timestamp);
                     let _ = self.settings.save();
-                    self.data_provider = DataProvider::Online(
-                        Box::new(data.clone()),
-                        Box::new(self.items_game.clone()),
-                        self.translations.clone(),
-                    );
+                    self.data_provider = DataProvider::Online {
+                        data: Arc::new(data.clone()),
+                        items_game: Arc::clone(&self.items_game),
+                        translations: Arc::clone(&self.translations),
+                    };
                     self.online_data = Some(data);
                     self.is_loading_online = false;
                     self.online_data_receiver = None;
@@ -783,22 +797,44 @@ impl CsgoInventoryEditor {
     }
 
     pub fn request_manual_update(&mut self) {
+        if self.is_fetching_online_data() {
+            return;
+        }
         println!("[request_manual_update] Setting is_loading_online = true");
         self.is_loading_online = true;
-        self.start_fetch_online_data();
+        self.load_online_data();
     }
 
-    pub fn get_sorted_inventory_ids(&mut self) -> &[u64] {
+    pub fn refresh_inventory_cache(&mut self) {
         if self.cached_items_count != self.inventory.items.len() {
             self.update_sorted_cache();
         }
-        &self.cached_sorted_inventory_ids
+    }
+
+    pub fn get_sorted_inventory_indices(&self) -> &[usize] {
+        &self.cached_sorted_inventory_indices
+    }
+
+    pub fn get_item_index(&self, item_id: u64) -> Option<usize> {
+        self.cached_item_indices_by_id.get(&item_id).copied()
+    }
+
+    pub fn mark_inventory_changed(&mut self) {
+        self.cached_items_count = usize::MAX;
+        self.cached_item_display_names.borrow_mut().clear();
     }
 
     fn update_sorted_cache(&mut self) {
-        self.cached_sorted_inventory_ids =
-            self.inventory.items.iter().map(|item| item.id).collect();
-        self.cached_sorted_inventory_ids.sort_by(|a, b| b.cmp(a));
+        self.cached_sorted_inventory_indices = (0..self.inventory.items.len()).collect();
+        self.cached_sorted_inventory_indices
+            .sort_by_key(|&idx| std::cmp::Reverse(self.inventory.items[idx].id));
+        self.cached_item_indices_by_id = self
+            .inventory
+            .items
+            .iter()
+            .enumerate()
+            .map(|(idx, item)| (item.id, idx))
+            .collect();
         self.cached_items_count = self.inventory.items.len();
         self.cached_item_display_names.borrow_mut().clear();
     }
@@ -808,8 +844,8 @@ impl Default for CsgoInventoryEditor {
     fn default() -> Self {
         Self {
             inventory: Inventory::default(),
-            items_game: ItemsGame::default(),
-            translations: GameTranslation::default(),
+            items_game: Arc::new(ItemsGame::default()),
+            translations: Arc::new(GameTranslation::default()),
             selected_category: InventoryCategory::All,
             selected_subcategory: None,
             search_query: String::new(),
@@ -836,14 +872,18 @@ impl Default for CsgoInventoryEditor {
             pending_graffiti_tint_select: None,
             pending_attribute_select: None,
             settings: Settings::default(),
-            data_provider: DataProvider::Local(Box::default(), GameTranslation::default()),
+            data_provider: DataProvider::Local {
+                items_game: Arc::new(ItemsGame::default()),
+                translations: Arc::new(GameTranslation::default()),
+            },
             online_data: None,
             is_loading_online: false,
             online_data_receiver: None,
             current_page: Page::default(),
             current_settings_page: SettingsPage::default(),
             config: Config::default(),
-            cached_sorted_inventory_ids: Vec::new(),
+            cached_sorted_inventory_indices: Vec::new(),
+            cached_item_indices_by_id: HashMap::new(),
             cached_items_count: 0,
             cached_item_display_names: RefCell::new(HashMap::new()),
             inventory_load_error: None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -240,12 +240,13 @@ pub struct CsgoInventoryEditor {
     pub pending_attribute_select: Option<u64>,
     pub settings: Settings,
     pub data_provider: DataProvider,
-    pub online_data: Option<OnlineGameData>,
     pub is_loading_online: bool,
     online_data_receiver: Option<Receiver<OnlineDataFetchResult>>,
     pub current_page: Page,
     pub current_settings_page: SettingsPage,
     pub config: Config,
+    cached_quality_names: Vec<(u32, String)>,
+    cached_rarity_names: Vec<(u32, String)>,
     cached_sorted_inventory_indices: Vec<usize>,
     cached_item_indices_by_id: HashMap<u64, usize>,
     cached_items_count: usize,
@@ -425,12 +426,13 @@ impl CsgoInventoryEditor {
                 items_game: Arc::clone(&items_game),
                 translations: Arc::clone(&translations),
             },
-            online_data: None,
             is_loading_online: false,
             online_data_receiver: None,
             current_page: Page::default(),
             current_settings_page: SettingsPage::default(),
             config,
+            cached_quality_names: Vec::new(),
+            cached_rarity_names: Vec::new(),
             cached_sorted_inventory_indices: Vec::new(),
             cached_item_indices_by_id: HashMap::new(),
             cached_items_count: 0,
@@ -447,10 +449,10 @@ impl CsgoInventoryEditor {
                 items_game,
                 translations,
             };
-            app.online_data = Some(data);
             app.settings.last_online_update = Some(timestamp);
         }
 
+        app.refresh_display_metadata_cache();
         app
     }
 
@@ -479,6 +481,7 @@ impl CsgoInventoryEditor {
                 match LanguageFileParser::load(&lang_file) {
                     Ok(t) => {
                         self.translations = Arc::new(t);
+                        self.refresh_display_metadata_cache();
                     }
                     Err(e) => eprintln!("Failed to load language file: {}", e),
                 }
@@ -496,7 +499,6 @@ impl CsgoInventoryEditor {
                     items_game: Arc::clone(&self.items_game),
                     translations: Arc::clone(&self.translations),
                 };
-                self.online_data = Some(data);
                 self.settings.last_online_update = Some(timestamp);
                 let _ = self.settings.save();
             } else {
@@ -505,7 +507,6 @@ impl CsgoInventoryEditor {
                     items_game: Arc::clone(&self.items_game),
                     translations: Arc::clone(&self.translations),
                 };
-                self.online_data = None;
             }
         } else {
             self.data_provider = DataProvider::Local {
@@ -513,6 +514,8 @@ impl CsgoInventoryEditor {
                 translations: Arc::clone(&self.translations),
             };
         }
+
+        self.refresh_display_metadata_cache();
     }
 
     pub fn apply_theme(&mut self, ctx: &egui::Context) {
@@ -772,7 +775,6 @@ impl CsgoInventoryEditor {
                         items_game: Arc::clone(&self.items_game),
                         translations: Arc::clone(&self.translations),
                     };
-                    self.online_data = Some(data);
                     self.is_loading_online = false;
                     self.online_data_receiver = None;
                     self.cached_item_display_names.borrow_mut().clear();
@@ -811,6 +813,14 @@ impl CsgoInventoryEditor {
         }
     }
 
+    pub fn get_cached_quality_names(&self) -> &[(u32, String)] {
+        &self.cached_quality_names
+    }
+
+    pub fn get_cached_rarity_names(&self) -> &[(u32, String)] {
+        &self.cached_rarity_names
+    }
+
     pub fn get_sorted_inventory_indices(&self) -> &[usize] {
         &self.cached_sorted_inventory_indices
     }
@@ -837,6 +847,25 @@ impl CsgoInventoryEditor {
             .collect();
         self.cached_items_count = self.inventory.items.len();
         self.cached_item_display_names.borrow_mut().clear();
+    }
+
+    fn refresh_display_metadata_cache(&mut self) {
+        self.cached_quality_names = self
+            .items_game
+            .get_all_qualities_sorted()
+            .into_iter()
+            .map(|(value, key)| {
+                let display_name = self.translations.get(&key).cloned().unwrap_or(key);
+                (value, display_name)
+            })
+            .collect();
+
+        self.cached_rarity_names = self
+            .items_game
+            .get_all_rarities_sorted()
+            .into_iter()
+            .map(|(value, _)| (value, self.get_rarity_name(value)))
+            .collect();
     }
 }
 
@@ -876,12 +905,13 @@ impl Default for CsgoInventoryEditor {
                 items_game: Arc::new(ItemsGame::default()),
                 translations: Arc::new(GameTranslation::default()),
             },
-            online_data: None,
             is_loading_online: false,
             online_data_receiver: None,
             current_page: Page::default(),
             current_settings_page: SettingsPage::default(),
             config: Config::default(),
+            cached_quality_names: Vec::new(),
+            cached_rarity_names: Vec::new(),
             cached_sorted_inventory_indices: Vec::new(),
             cached_item_indices_by_id: HashMap::new(),
             cached_items_count: 0,

--- a/src/app.rs
+++ b/src/app.rs
@@ -545,8 +545,7 @@ impl CsgoInventoryEditor {
             let result = InventoryLoader::save_to_game_dir(&self.inventory, game_dir.path())
                 .map_err(|e| e.to_string());
             if result.is_ok() {
-                self.cached_item_display_names.borrow_mut().clear();
-                self.cached_items_count = self.inventory.items.len();
+                self.update_sorted_cache();
             }
             result
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,6 +186,7 @@ impl eframe::App for CsgoInventoryEditor {
                     new_item.inventory = new_inventory_id;
 
                     self.inventory.items.push(new_item);
+                    self.mark_inventory_changed();
                     self.open_item_windows.insert(new_item_id);
                     let _ = self.save_inventory();
                 }
@@ -285,6 +286,7 @@ impl eframe::App for CsgoInventoryEditor {
                     new_item.inventory = new_inventory_id;
 
                     self.inventory.items.push(new_item);
+                    self.mark_inventory_changed();
                     self.open_item_windows.insert(new_item_id);
                     let _ = self.save_inventory();
                 }

--- a/src/online_data/provider.rs
+++ b/src/online_data/provider.rs
@@ -1,19 +1,32 @@
 use crate::inventory::item_attribute::ItemAttribute;
 use crate::inventory::{GameTranslation, Item, ItemsGame};
 use crate::online_data::models::OnlineGameData;
+use std::sync::Arc;
 
 pub enum DataProvider {
-    Local(Box<ItemsGame>, GameTranslation),
-    Online(Box<OnlineGameData>, Box<ItemsGame>, GameTranslation),
+    Local {
+        items_game: Arc<ItemsGame>,
+        translations: Arc<GameTranslation>,
+    },
+    Online {
+        data: Arc<OnlineGameData>,
+        items_game: Arc<ItemsGame>,
+        translations: Arc<GameTranslation>,
+    },
 }
 
 impl DataProvider {
     pub fn get_item_display_name(&self, def_index: u32) -> String {
         match self {
-            DataProvider::Local(items_game, translations) => {
-                items_game.get_item_display_name(def_index, translations)
-            }
-            DataProvider::Online(_data, items_game, translations) => {
+            DataProvider::Local {
+                items_game,
+                translations,
+            } => items_game.get_item_display_name(def_index, translations),
+            DataProvider::Online {
+                data: _data,
+                items_game,
+                translations,
+            } => {
                 // Force use local data for display name (online format incompatible)
                 items_game.get_item_display_name(def_index, translations)
             }
@@ -22,10 +35,15 @@ impl DataProvider {
 
     pub fn get_paint_kit_display_name(&self, paint_index: u32) -> Option<String> {
         match self {
-            DataProvider::Local(items_game, translations) => {
-                items_game.get_paint_kit_display_name(paint_index, translations)
-            }
-            DataProvider::Online(_data, items_game, translations) => {
+            DataProvider::Local {
+                items_game,
+                translations,
+            } => items_game.get_paint_kit_display_name(paint_index, translations),
+            DataProvider::Online {
+                data: _data,
+                items_game,
+                translations,
+            } => {
                 // Force use local data for display name (online format incompatible)
                 items_game.get_paint_kit_display_name(paint_index, translations)
             }
@@ -35,10 +53,15 @@ impl DataProvider {
     // Get skin display name from online inventory data (requires weapon_id and paint_index)
     pub fn get_skin_display_name(&self, weapon_id: u32, paint_index: u32) -> Option<String> {
         match self {
-            DataProvider::Local(items_game, translations) => {
-                items_game.get_paint_kit_display_name(paint_index, translations)
-            }
-            DataProvider::Online(data, items_game, translations) => {
+            DataProvider::Local {
+                items_game,
+                translations,
+            } => items_game.get_paint_kit_display_name(paint_index, translations),
+            DataProvider::Online {
+                data,
+                items_game,
+                translations,
+            } => {
                 // Try online inventory data first
                 if let Some(skin) = data.get_inventory_skin(weapon_id, paint_index) {
                     return Some(skin.name.clone());
@@ -51,10 +74,15 @@ impl DataProvider {
 
     pub fn get_sticker_kit_display_name(&self, sticker_index: u32) -> Option<String> {
         match self {
-            DataProvider::Local(items_game, translations) => {
-                items_game.get_sticker_kit_display_name(sticker_index, translations)
-            }
-            DataProvider::Online(data, items_game, translations) => {
+            DataProvider::Local {
+                items_game,
+                translations,
+            } => items_game.get_sticker_kit_display_name(sticker_index, translations),
+            DataProvider::Online {
+                data,
+                items_game,
+                translations,
+            } => {
                 if let Some(sticker) = data.get_inventory_sticker(sticker_index) {
                     return Some(sticker.name.clone());
                 }
@@ -65,10 +93,15 @@ impl DataProvider {
 
     pub fn get_music_def_display_name(&self, music_index: u32) -> Option<String> {
         match self {
-            DataProvider::Local(items_game, translations) => {
-                items_game.get_music_def_display_name(music_index, translations)
-            }
-            DataProvider::Online(data, items_game, translations) => {
+            DataProvider::Local {
+                items_game,
+                translations,
+            } => items_game.get_music_def_display_name(music_index, translations),
+            DataProvider::Online {
+                data,
+                items_game,
+                translations,
+            } => {
                 // Try online inventory data first
                 if let Some(music_kit) = data.get_inventory_music_kit(music_index) {
                     return Some(music_kit.name.clone());
@@ -81,22 +114,30 @@ impl DataProvider {
 
     pub fn get_paint_kit_rarity(&self, paint_index: u32) -> Option<u32> {
         match self {
-            DataProvider::Local(items_game, _translations) => {
-                items_game.get_paint_kit_rarity(paint_index)
-            }
-            DataProvider::Online(_data, items_game, _translations) => {
-                items_game.get_paint_kit_rarity(paint_index)
-            }
+            DataProvider::Local {
+                items_game,
+                translations: _translations,
+            } => items_game.get_paint_kit_rarity(paint_index),
+            DataProvider::Online {
+                data: _data,
+                items_game,
+                translations: _translations,
+            } => items_game.get_paint_kit_rarity(paint_index),
         }
     }
 
     // Get skin rarity from online inventory data (requires weapon_id and paint_index)
     pub fn get_skin_rarity(&self, weapon_id: u32, paint_index: u32) -> Option<u32> {
         match self {
-            DataProvider::Local(items_game, _translations) => {
-                items_game.get_paint_kit_rarity(paint_index)
-            }
-            DataProvider::Online(data, items_game, _translations) => {
+            DataProvider::Local {
+                items_game,
+                translations: _translations,
+            } => items_game.get_paint_kit_rarity(paint_index),
+            DataProvider::Online {
+                data,
+                items_game,
+                translations: _translations,
+            } => {
                 // Try online inventory data first
                 if let Some(skin) = data.get_inventory_skin(weapon_id, paint_index)
                     && let Some(ref rarity) = skin.rarity
@@ -120,13 +161,13 @@ impl DataProvider {
         {
             let paint_id = paint_id_f32 as u32;
             match self {
-                DataProvider::Local(_, _) => {
+                DataProvider::Local { .. } => {
                     // Local mode: combine item name and paint name
                     if let Some(paint_name) = self.get_skin_display_name(item.def_index, paint_id) {
                         return format!("{} | {}", item_name, paint_name);
                     }
                 }
-                DataProvider::Online(data, _, _) => {
+                DataProvider::Online { data, .. } => {
                     // Online mode: skin name is already full name (e.g., "AK-47 | Redline")
                     if let Some(skin) = data.get_inventory_skin(item.def_index, paint_id) {
                         return skin.name.clone();
@@ -143,13 +184,13 @@ impl DataProvider {
             && let Ok(music_id) = music_index.parse::<u32>()
         {
             match self {
-                DataProvider::Local(_, _) => {
+                DataProvider::Local { .. } => {
                     // Local mode: combine item name and music name
                     if let Some(music_name) = self.get_music_def_display_name(music_id) {
                         return format!("{} | {}", item_name, music_name);
                     }
                 }
-                DataProvider::Online(data, _, _) => {
+                DataProvider::Online { data, .. } => {
                     // Online mode: music kit name is already full name
                     if let Some(music_kit) = data.get_inventory_music_kit(music_id) {
                         return music_kit.name.clone();
@@ -166,12 +207,12 @@ impl DataProvider {
             && let Ok(sticker_id) = sticker_index.parse::<u32>()
         {
             match self {
-                DataProvider::Local(_, _) => {
+                DataProvider::Local { .. } => {
                     if let Some(sticker_name) = self.get_sticker_kit_display_name(sticker_id) {
                         return format!("{} | {}", item_name, sticker_name);
                     }
                 }
-                DataProvider::Online(data, _, _) => {
+                DataProvider::Online { data, .. } => {
                     if let Some(sticker) = data.get_inventory_sticker(sticker_id) {
                         return sticker.name.clone();
                     }
@@ -187,10 +228,15 @@ impl DataProvider {
 
     pub fn create_item_select_list(&self) -> Vec<(String, String, String)> {
         match self {
-            DataProvider::Local(items_game, translations) => {
-                items_game.create_item_select_list(translations)
-            }
-            DataProvider::Online(_data, items_game, translations) => {
+            DataProvider::Local {
+                items_game,
+                translations,
+            } => items_game.create_item_select_list(translations),
+            DataProvider::Online {
+                data: _data,
+                items_game,
+                translations,
+            } => {
                 // Force use local data for display name (online format incompatible)
                 items_game.create_item_select_list(translations)
             }
@@ -199,10 +245,15 @@ impl DataProvider {
 
     pub fn create_paint_kit_select_list(&self) -> Vec<(String, String, String)> {
         match self {
-            DataProvider::Local(items_game, translations) => {
-                items_game.create_paint_kit_select_list(translations)
-            }
-            DataProvider::Online(_data, items_game, translations) => {
+            DataProvider::Local {
+                items_game,
+                translations,
+            } => items_game.create_paint_kit_select_list(translations),
+            DataProvider::Online {
+                data: _data,
+                items_game,
+                translations,
+            } => {
                 // Force use local data for display name (online format incompatible)
                 items_game.create_paint_kit_select_list(translations)
             }
@@ -216,12 +267,19 @@ impl DataProvider {
         weapon_id: u32,
     ) -> Vec<(String, String, String, Option<String>)> {
         match self {
-            DataProvider::Local(items_game, translations) => items_game
+            DataProvider::Local {
+                items_game,
+                translations,
+            } => items_game
                 .create_paint_kit_select_list(translations)
                 .into_iter()
                 .map(|(id, name, value)| (id, name, value, None))
                 .collect(),
-            DataProvider::Online(data, items_game, translations) => {
+            DataProvider::Online {
+                data,
+                items_game,
+                translations,
+            } => {
                 // Use online inventory data to get skins for this weapon
                 if let Some(ref inventory) = data.inventory
                     && let Some(skins) = inventory.skins.get(&weapon_id.to_string())
@@ -254,12 +312,19 @@ impl DataProvider {
 
     pub fn create_music_def_select_list(&self) -> Vec<(String, String, String, Option<String>)> {
         match self {
-            DataProvider::Local(items_game, translations) => items_game
+            DataProvider::Local {
+                items_game,
+                translations,
+            } => items_game
                 .create_music_def_select_list(translations)
                 .into_iter()
                 .map(|(id, name, value)| (id, name, value, None))
                 .collect(),
-            DataProvider::Online(data, items_game, translations) => {
+            DataProvider::Online {
+                data,
+                items_game,
+                translations,
+            } => {
                 // Use online inventory data for music kits with color
                 if let Some(ref inventory) = data.inventory {
                     let mut items: Vec<(String, String, String, Option<String>)> = inventory
@@ -290,12 +355,19 @@ impl DataProvider {
 
     pub fn create_sticker_kit_select_list(&self) -> Vec<(String, String, String, Option<String>)> {
         match self {
-            DataProvider::Local(items_game, translations) => items_game
+            DataProvider::Local {
+                items_game,
+                translations,
+            } => items_game
                 .create_sticker_kit_select_list(translations)
                 .into_iter()
                 .map(|(id, name, value)| (id, name, value, None))
                 .collect(),
-            DataProvider::Online(data, items_game, translations) => {
+            DataProvider::Online {
+                data,
+                items_game,
+                translations,
+            } => {
                 // Use online inventory data for stickers with color
                 if let Some(ref inventory) = data.inventory {
                     let mut items: Vec<(String, String, String, Option<String>)> = inventory
@@ -326,43 +398,43 @@ impl DataProvider {
 
     pub fn get_all_rarities_sorted(&self) -> Vec<(u32, String)> {
         match self {
-            DataProvider::Local(items_game, _translations) => items_game.get_all_rarities_sorted(),
-            DataProvider::Online(_, items_game, _) => items_game.get_all_rarities_sorted(),
+            DataProvider::Local {
+                items_game,
+                translations: _translations,
+            } => items_game.get_all_rarities_sorted(),
+            DataProvider::Online {
+                data: _,
+                items_game,
+                translations: _,
+            } => items_game.get_all_rarities_sorted(),
         }
     }
 
     pub fn get_all_qualities_sorted(&self) -> Vec<(u32, String)> {
         match self {
-            DataProvider::Local(items_game, _translations) => items_game.get_all_qualities_sorted(),
-            DataProvider::Online(_, items_game, _) => items_game.get_all_qualities_sorted(),
+            DataProvider::Local {
+                items_game,
+                translations: _translations,
+            } => items_game.get_all_qualities_sorted(),
+            DataProvider::Online {
+                data: _,
+                items_game,
+                translations: _,
+            } => items_game.get_all_qualities_sorted(),
         }
     }
 
-    pub fn as_items_game(&self) -> Option<&ItemsGame> {
+    pub fn items_game(&self) -> &Arc<ItemsGame> {
         match self {
-            DataProvider::Local(items_game, _) => Some(items_game),
-            DataProvider::Online(_, items_game, _) => Some(items_game),
+            DataProvider::Local { items_game, .. } => items_game,
+            DataProvider::Online { items_game, .. } => items_game,
         }
     }
 
-    pub fn as_items_game_mut(&mut self) -> Option<&mut ItemsGame> {
+    pub fn translations(&self) -> &Arc<GameTranslation> {
         match self {
-            DataProvider::Local(items_game, _) => Some(items_game),
-            DataProvider::Online(_, items_game, _) => Some(items_game),
-        }
-    }
-
-    pub fn as_translations(&self) -> Option<&GameTranslation> {
-        match self {
-            DataProvider::Local(_, translations) => Some(translations),
-            DataProvider::Online(_, _, translations) => Some(translations),
-        }
-    }
-
-    pub fn as_translations_mut(&mut self) -> Option<&mut GameTranslation> {
-        match self {
-            DataProvider::Local(_, translations) => Some(translations),
-            DataProvider::Online(_, _, translations) => Some(translations),
+            DataProvider::Local { translations, .. } => translations,
+            DataProvider::Online { translations, .. } => translations,
         }
     }
 }

--- a/src/ui/item_detail.rs
+++ b/src/ui/item_detail.rs
@@ -12,24 +12,24 @@ pub fn draw_item_detail_windows(
     pending_select_window_items: &mut Option<SelectWindowItems>,
     select_window_open: &mut bool,
 ) {
+    state.refresh_inventory_cache();
     let open_windows = state.open_item_windows.clone();
     let items_game_ref = &state.items_game;
     let translations_ref = &state.translations;
     let mut windows_to_close: Vec<u64> = Vec::new();
     let mut pending_save_item_id: Option<u64> = None;
-    let mut pending_save_and_close: bool = false;
     let mut pending_open_select_window: Option<SelectWindowItems> = None;
 
     for item_id in open_windows {
-        let item_opt = state.inventory.items.iter().find(|i| i.id == item_id);
-        if item_opt.is_none() {
+        let Some(item_idx) = state.get_item_index(item_id) else {
             state.open_item_windows.remove(&item_id);
             continue;
-        }
+        };
 
-        let item = item_opt.unwrap();
+        let item = &state.inventory.items[item_idx];
         let display_name = state.get_item_display_name(item);
         let mut window_open = true;
+        let mut pending_save_and_close = false;
 
         let mut should_open_select_window = false;
 
@@ -410,8 +410,9 @@ pub fn draw_item_detail_windows(
 
     if let Some(item_id) = pending_save_item_id
         && let Some(edit_state) = state.edit_item_states.get(&item_id)
-        && let Some(item) = state.inventory.items.iter_mut().find(|i| i.id == item_id)
+        && let Some(item_idx) = state.get_item_index(item_id)
     {
+        let item = &mut state.inventory.items[item_idx];
         item.level = edit_state.level;
         item.rarity = edit_state.rarity;
         item.quality = edit_state.quality;
@@ -469,8 +470,9 @@ pub fn draw_item_detail_windows(
         });
 
         if delete_confirmed {
-            if let Some(pos) = state.inventory.items.iter().position(|i| i.id == item_id) {
-                state.inventory.items.remove(pos);
+            if let Some(item_idx) = state.get_item_index(item_id) {
+                state.inventory.items.remove(item_idx);
+                state.mark_inventory_changed();
                 state.open_item_windows.remove(&item_id);
                 state.edit_item_states.remove(&item_id);
 

--- a/src/ui/item_detail.rs
+++ b/src/ui/item_detail.rs
@@ -55,7 +55,8 @@ pub fn draw_item_detail_windows(
 
         let mut edit_state = state
             .edit_item_states
-            .remove(&item_id)
+            .get(&item_id)
+            .cloned()
             .expect("edit state should exist after insertion");
 
         let has_unsaved_changes = edit_state.level != item_level

--- a/src/ui/item_detail.rs
+++ b/src/ui/item_detail.rs
@@ -68,7 +68,9 @@ pub fn draw_item_detail_windows(
             .id(egui::Id::new(format!("item_window_{}", item_id)))
             .movable(true)
             .collapsible(true)
-            .resizable(false)
+            .resizable(true)
+            .default_size(egui::vec2(720.0, 560.0))
+            .min_size(egui::vec2(460.0, 320.0))
             .open(&mut window_open)
             .show(ctx, |ui| {
                 ui.horizontal(|ui| {

--- a/src/ui/item_detail.rs
+++ b/src/ui/item_detail.rs
@@ -14,8 +14,6 @@ pub fn draw_item_detail_windows(
 ) {
     state.refresh_inventory_cache();
     let open_windows = state.open_item_windows.clone();
-    let items_game_ref = &state.items_game;
-    let translations_ref = &state.translations;
     let mut windows_to_close: Vec<u64> = Vec::new();
     let mut pending_save_item_id: Option<u64> = None;
     let mut pending_open_select_window: Option<SelectWindowItems> = None;
@@ -27,7 +25,16 @@ pub fn draw_item_detail_windows(
         };
 
         let item = &state.inventory.items[item_idx];
+        let item_def_index = item.def_index;
+        let item_level = item.level;
+        let item_rarity = item.rarity;
+        let item_quality = item.quality;
+        let item_attributes = item.attributes.clone();
+        let base_custom_name = item.custom_name.clone().unwrap_or_default();
         let display_name = state.get_item_display_name(item);
+        let item_base_name = state
+            .items_game
+            .get_item_display_name(item_def_index, &state.translations);
         let mut window_open = true;
         let mut pending_save_and_close = false;
 
@@ -39,31 +46,23 @@ pub fn draw_item_detail_windows(
             .edit_item_states
             .entry(item_id)
             .or_insert_with(|| EditItemState {
-                level: item.level,
-                custom_name: item.custom_name.clone().unwrap_or_default(),
-                rarity: item.rarity,
-                quality: item.quality,
-                attributes: item.attributes.clone(),
+                level: item_level,
+                custom_name: base_custom_name.clone(),
+                rarity: item_rarity,
+                quality: item_quality,
+                attributes: item_attributes.clone(),
             });
 
-        let edit_state = state
+        let mut edit_state = state
             .edit_item_states
-            .get(&item_id)
-            .cloned()
-            .unwrap_or_else(|| EditItemState {
-                level: item.level,
-                custom_name: item.custom_name.clone().unwrap_or_default(),
-                rarity: item.rarity,
-                quality: item.quality,
-                attributes: item.attributes.clone(),
-            });
-        let mut edit_state = edit_state;
+            .remove(&item_id)
+            .expect("edit state should exist after insertion");
 
-        let has_unsaved_changes = edit_state.level != item.level
-            || edit_state.custom_name != item.custom_name.clone().unwrap_or_default()
-            || edit_state.rarity != item.rarity
-            || edit_state.quality != item.quality
-            || edit_state.attributes != item.attributes;
+        let has_unsaved_changes = edit_state.level != item_level
+            || edit_state.custom_name != base_custom_name
+            || edit_state.rarity != item_rarity
+            || edit_state.quality != item_quality
+            || edit_state.attributes != item_attributes;
 
         egui::Window::new(format!("{} - {}", tr!("item-detail"), display_name))
             .id(egui::Id::new(format!("item_window_{}", item_id)))
@@ -72,9 +71,6 @@ pub fn draw_item_detail_windows(
             .resizable(false)
             .open(&mut window_open)
             .show(ctx, |ui| {
-                let item_base_name =
-                    items_game_ref.get_item_display_name(item.def_index, translations_ref);
-
                 ui.horizontal(|ui| {
                     if ui.button(tr!("btn-save")).clicked() {
                         pending_save_item_id = Some(item_id);
@@ -126,14 +122,10 @@ pub fn draw_item_detail_windows(
                         row.col(|ui| {
                             ui.horizontal(|ui| {
                                 ui.label(item_base_name.to_string());
-                                ui.label(format!("({})", item.def_index));
+                                ui.label(format!("({})", item_def_index));
                                 ui.add_space(10.0);
                                 if ui.button(tr!("btn-select")).clicked() {
-                                    let items = items_game_ref
-                                        .create_item_select_list(translations_ref)
-                                        .into_iter()
-                                        .map(|(id, name, value)| (id, name, value, None))
-                                        .collect();
+                                    let items = state.create_item_select_list();
                                     *pending_select_window_items = Some(items);
                                     should_open_select_window = true;
                                     state.select_window_for_item = Some(item_id);
@@ -156,11 +148,11 @@ pub fn draw_item_detail_windows(
                             ui.label(tr!("quality-id"));
                         });
                         row.col(|ui| {
-                            let all_qualities = items_game_ref.get_all_qualities_sorted();
+                            let all_qualities = state.get_cached_quality_names();
                             let selected_name = all_qualities
                                 .iter()
                                 .find(|(v, _)| *v == edit_state.quality)
-                                .and_then(|(_, name)| translations_ref.get(name).cloned())
+                                .map(|(_, name)| name.clone())
                                 .unwrap_or_else(|| format!("Unknown ({})", edit_state.quality));
 
                             egui::ComboBox::from_id_salt(format!("quality_combo_{}", item_id))
@@ -169,15 +161,11 @@ pub fn draw_item_detail_windows(
                                     selected_name, edit_state.quality
                                 ))
                                 .show_ui(ui, |ui| {
-                                    for (value, name) in &all_qualities {
-                                        let display_name = translations_ref
-                                            .get(name)
-                                            .cloned()
-                                            .unwrap_or_else(|| name.clone());
+                                    for (value, name) in all_qualities {
                                         ui.selectable_value(
                                             &mut edit_state.quality,
                                             *value,
-                                            format!("{} ({})", display_name, value),
+                                            format!("{} ({})", name, value),
                                         );
                                     }
                                 });
@@ -189,33 +177,7 @@ pub fn draw_item_detail_windows(
                             ui.label(tr!("rarity"));
                         });
                         row.col(|ui| {
-                            let all_rarities = items_game_ref.get_all_rarities_sorted();
-                            let rarity_names: Vec<(u32, String)> = all_rarities
-                                .iter()
-                                .map(|(value, _loc_key)| {
-                                    let name = if let Some(rarity) =
-                                        items_game_ref.rarities.values().find(|r| r.value == *value)
-                                    {
-                                        let display_name = translations_ref
-                                            .get(&rarity.loc_key)
-                                            .cloned()
-                                            .unwrap_or_else(|| rarity.loc_key.clone());
-
-                                        if let Some(weapon_key) = &rarity.loc_key_weapon {
-                                            let weapon_name = translations_ref
-                                                .get(weapon_key)
-                                                .cloned()
-                                                .unwrap_or_else(|| weapon_key.clone());
-                                            format!("{} | {}", display_name, weapon_name)
-                                        } else {
-                                            display_name
-                                        }
-                                    } else {
-                                        format!("Unknown ({})", value)
-                                    };
-                                    (*value, name)
-                                })
-                                .collect();
+                            let rarity_names = state.get_cached_rarity_names();
 
                             let selected_name = rarity_names
                                 .iter()
@@ -226,7 +188,7 @@ pub fn draw_item_detail_windows(
                             egui::ComboBox::from_id_salt(format!("rarity_combo_{}", item_id))
                                 .selected_text(format!("{} ({})", selected_name, edit_state.rarity))
                                 .show_ui(ui, |ui| {
-                                    for (value, name) in &rarity_names {
+                                    for (value, name) in rarity_names {
                                         ui.selectable_value(
                                             &mut edit_state.rarity,
                                             *value,
@@ -309,14 +271,14 @@ pub fn draw_item_detail_windows(
                                 .get(attr_id)
                                 .cloned()
                                 .unwrap_or_else(|| {
-                                    item.attributes.get(attr_id).cloned().unwrap_or_default()
+                                    item_attributes.get(attr_id).cloned().unwrap_or_default()
                                 });
 
                             let attr_value_display = get_attribute_value_display_name(
                                 *attr_id,
                                 &edit_value,
-                                items_game_ref,
-                                translations_ref,
+                                &state.items_game,
+                                &state.translations,
                             );
 
                             body.row(30.0, |mut row| {
@@ -333,7 +295,7 @@ pub fn draw_item_detail_windows(
                                             ui.add_space(10.0);
                                             if ui.button(tr!("btn-select")).clicked() {
                                                 state.pending_paint_kit_select =
-                                                    Some((item_id_for_edit, item.def_index));
+                                                    Some((item_id_for_edit, item_def_index));
                                             }
                                         });
                                     } else if *attr_id == 166 {

--- a/src/ui/item_grid.rs
+++ b/src/ui/item_grid.rs
@@ -1,12 +1,12 @@
 use crate::app::CsgoInventoryEditor;
 use crate::app::Rarity;
 use eframe::egui;
-use std::collections::HashMap;
 
 pub fn draw_item_grid(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     let items_per_row = 8;
     let card_height = 100.0;
     let spacing = 8.0;
+    let mut clicked_item_id = None;
 
     egui::ScrollArea::vertical().show(ui, |ui| {
         ui.add_space(8.0);
@@ -16,14 +16,7 @@ pub fn draw_item_grid(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
         let card_width = (available_width - total_spacing) / items_per_row as f32;
 
         let font_size = (card_width * 0.16).clamp(12.0, 20.0);
-
-        let items_map: HashMap<u64, usize> = state
-            .inventory
-            .items
-            .iter()
-            .enumerate()
-            .map(|(idx, item)| (item.id, idx))
-            .collect();
+        state.refresh_inventory_cache();
 
         egui::Grid::new("item_grid")
             .num_columns(items_per_row)
@@ -31,13 +24,7 @@ pub fn draw_item_grid(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
             .min_col_width(card_width)
             .min_row_height(card_height)
             .show(ui, |ui| {
-                let sorted_ids = state.get_sorted_inventory_ids().to_vec();
-
-                for (i, inventory_id) in sorted_ids.iter().enumerate() {
-                    let item_idx = match items_map.get(inventory_id) {
-                        Some(&idx) => idx,
-                        None => continue,
-                    };
+                for (i, &item_idx) in state.get_sorted_inventory_indices().iter().enumerate() {
                     let item = &state.inventory.items[item_idx];
 
                     let display_name = state.get_item_display_name(item);
@@ -170,7 +157,7 @@ pub fn draw_item_grid(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
                     );
 
                     if card_response.clicked() {
-                        state.open_item_windows.insert(item.id);
+                        clicked_item_id = Some(item.id);
                     }
 
                     if (i + 1) % items_per_row == 0 {
@@ -181,4 +168,8 @@ pub fn draw_item_grid(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
 
         ui.add_space(8.0);
     });
+
+    if let Some(item_id) = clicked_item_id {
+        state.open_item_windows.insert(item_id);
+    }
 }

--- a/src/ui/item_grid.rs
+++ b/src/ui/item_grid.rs
@@ -16,6 +16,7 @@ pub fn draw_item_grid(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
         let card_width = (available_width - total_spacing) / items_per_row as f32;
 
         let font_size = (card_width * 0.16).clamp(12.0, 20.0);
+        let id_font_size = (font_size * 0.7).clamp(10.0, 14.0);
         state.refresh_inventory_cache();
 
         egui::Grid::new("item_grid")
@@ -80,14 +81,7 @@ pub fn draw_item_grid(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
                     let text_start_x = card_rect.min.x + text_margin + indicator_space;
                     let text_max_width = card_width - 2.0 * text_margin - indicator_space;
                     let text_max_height = card_height - 2.0 * text_margin;
-                    let _max_lines_per_text = 1;
-
-                    let id_font_size = (font_size * 0.7).clamp(10.0, 14.0);
                     let id_text = format!("#{}", item.id);
-
-                    let padding = 4.0;
-                    let actual_wrap_width = text_max_width - padding;
-                    let name_max_lines = 2;
 
                     let id_galley = ui.painter().fonts_mut(|fonts| {
                         fonts.layout(
@@ -100,39 +94,6 @@ pub fn draw_item_grid(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
 
                     let id_height = id_galley.size().y;
 
-                    let name_available_height = text_max_height - id_height - 4.0;
-                    let min_font_size = 10.0;
-
-                    let final_font_size = ui.painter().fonts_mut(|fonts| {
-                        let mut low = min_font_size;
-                        let mut high = font_size;
-                        let mut result = min_font_size;
-
-                        while low <= high {
-                            let mid = (low + high) / 2.0;
-                            let galley = fonts.layout(
-                                display_name.clone(),
-                                egui::FontId::proportional(mid),
-                                ui.visuals().text_color(),
-                                actual_wrap_width,
-                            );
-
-                            let galley_rows = galley.rows.len();
-                            let galley_height = galley.size().y;
-
-                            if galley_rows <= name_max_lines
-                                && galley_height <= name_available_height
-                            {
-                                result = mid;
-                                low = mid + 1.0;
-                            } else {
-                                high = mid - 1.0;
-                            }
-                        }
-
-                        result
-                    });
-
                     let id_text_start_y = card_rect.min.y + text_margin;
                     ui.painter().galley(
                         egui::Pos2::new(text_start_x, id_text_start_y),
@@ -141,17 +102,22 @@ pub fn draw_item_grid(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
                     );
 
                     let name_text_start_y = id_text_start_y + id_height + 4.0;
+                    let name_max_height = (text_max_height - id_height - 4.0).max(0.0);
+                    let name_rect = egui::Rect::from_min_size(
+                        egui::Pos2::new(text_start_x, name_text_start_y),
+                        egui::Vec2::new(text_max_width, name_max_height),
+                    );
                     let name_galley = ui.painter().fonts_mut(|fonts| {
                         fonts.layout(
                             display_name.clone(),
-                            egui::FontId::proportional(final_font_size),
+                            egui::FontId::proportional(font_size),
                             ui.visuals().text_color(),
-                            actual_wrap_width,
+                            text_max_width,
                         )
                     });
 
-                    ui.painter().galley(
-                        egui::Pos2::new(text_start_x, name_text_start_y),
+                    ui.painter().with_clip_rect(name_rect).galley(
+                        name_rect.min,
                         name_galley,
                         ui.visuals().text_color(),
                     );

--- a/src/ui/select_window.rs
+++ b/src/ui/select_window.rs
@@ -78,6 +78,8 @@ pub fn draw_select_window(
         .id(egui::Id::new("select_window"))
         .open(&mut window_open)
         .resizable(true)
+        .default_size(egui::vec2(720.0, 520.0))
+        .min_size(egui::vec2(420.0, 260.0))
         .collapsible(true)
         .movable(true)
         .show(ctx, |ui| {
@@ -99,9 +101,9 @@ pub fn draw_select_window(
 
             let table = TableBuilder::new(ui)
                 .striped(true)
-                .resizable(true)
+                .resizable(false)
                 .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-                .column(Column::auto().resizable(true))
+                .column(Column::auto())
                 .column(Column::remainder())
                 .max_scroll_height(max_table_height)
                 .sense(egui::Sense::click());

--- a/src/ui/settings_page.rs
+++ b/src/ui/settings_page.rs
@@ -226,19 +226,11 @@ fn draw_settings_content(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
             if button.clicked() {
                 state.request_manual_update();
             }
-            if state.is_loading_online {
-                ui.spinner();
-            }
-        });
-
-        // Show loading status
-        if state.is_fetching_online_data() {
-            ui.add_space(8.0);
-            ui.horizontal(|ui| {
+            if state.is_fetching_online_data() {
                 ui.spinner();
                 ui.label(tr!("settings-updating"));
-            });
-        }
+            }
+        });
     });
 }
 


### PR DESCRIPTION
## Summary
- Refactor inventory UI hot paths to reduce per-frame cloning, sorting, and layout work in item grid and detail windows
- Share read-mostly game data with `Arc` and cache quality/rarity display metadata to reduce memory churn
- Prevent overlapping online update fetches and simplify update status UI to a single inline spinner/message
- Restore resizable item selection and item detail windows while keeping table column resizing disabled
- Narrow build script work to incremental asset copying and quieter change tracking

## Testing
- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo build`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gt-610/csgo-gc-inventory-editor/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
