### PR TITLE
ci: add macOS automated build workflow for Intel and Apple Silicon

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,40 +2,61 @@ name: Build Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v6
-    - name: Cache cargo registry
-      uses: actions/cache@v5
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo index
-      uses: actions/cache@v5
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo build
-      uses: actions/cache@v5
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-    - name: Check
-      run: cargo check
-    - name: Run tests
-      run: cargo test
-    - name: Clippy
-      run: cargo clippy -- -D warnings
-    - name: Format check
-      run: cargo fmt -- --check
+      - uses: actions/checkout@v6
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v5
+        with:
+          path: target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Rust target (macOS)
+        if: runner.os == 'macOS'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Check
+        run: cargo check --target ${{ matrix.target }}
+
+      - name: Run tests
+        run: cargo test --target ${{ matrix.target }}
+
+      - name: Clippy
+        run: cargo clippy --target ${{ matrix.target }} -- -D warnings
+
+      - name: Format check
+        run: cargo fmt -- --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,60 +11,116 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  release:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact_name: csgo-inventory-editor-windows
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            artifact_name: csgo-inventory-editor-macos-intel
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact_name: csgo-inventory-editor-macos-arm
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v5
+        with:
+          path: target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Rust target (macOS)
+        if: runner.os == 'macOS'
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build release
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package release (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $dir = "${{ matrix.artifact_name }}"
+          New-Item -ItemType Directory -Path $dir -Force
+          Copy-Item "target/${{ matrix.target }}/release/csgo-inventory-editor.exe" $dir
+          if (Test-Path "target/${{ matrix.target }}/release/csgo_gc") {
+            Copy-Item -Recurse "target/${{ matrix.target }}/release/csgo_gc" $dir
+          }
+          Compress-Archive -Path "$dir\*" -DestinationPath "${{ matrix.artifact_name }}.zip" -Force
+
+      - name: Package release (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          dir="${{ matrix.artifact_name }}"
+          mkdir -p "$dir"
+          cp "target/${{ matrix.target }}/release/csgo-inventory-editor" "$dir/"
+          if [ -d "target/${{ matrix.target }}/release/csgo_gc" ]; then
+            cp -R "target/${{ matrix.target }}/release/csgo_gc" "$dir/"
+          fi
+          zip -r "${{ matrix.artifact_name }}.zip" "$dir"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_name }}.zip
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     permissions:
       contents: write
 
     steps:
-    - uses: actions/checkout@v6
-    - name: Cache cargo registry
-      uses: actions/cache@v5
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo index
-      uses: actions/cache@v5
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo build
-      uses: actions/cache@v5
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-    - name: Build release
-      run: cargo build --release
-    - name: Create release
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        REPO: ${{ github.repository }}
-        SHA: ${{ github.sha }}
-      shell: pwsh
-      run: |
-        $TAG = "release"
+      - uses: actions/checkout@v6
 
-        gh release delete "$TAG" --cleanup-tag --repo "$REPO" --yes 2>$null
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
 
-        Start-Sleep -Seconds 10
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          TAG="release"
 
-        gh release create "$TAG" --repo "$REPO" `
-          --title "Rolling Release" `
-          --notes "$SHA"
+          # Delete existing release and tag if present
+          gh release delete "$TAG" --cleanup-tag --repo "$REPO" --yes 2>/dev/null || true
 
-        $filesToCompress = @()
-        if (Test-Path "target\release\csgo-inventory-editor.exe") {
-          $filesToCompress += "target\release\csgo-inventory-editor.exe"
-        }
-        if (Test-Path "target\release\csgo_gc") {
-          $filesToCompress += "target\release\csgo_gc"
-        }
+          sleep 10
 
-        if ($filesToCompress.Count -gt 0) {
-          Compress-Archive -Path $filesToCompress -DestinationPath "csgo-inventory-editor-windows.zip" -Force
-          gh release upload "$TAG" --repo "$REPO" --clobber "csgo-inventory-editor-windows.zip"
-        }
+          # Create fresh release
+          gh release create "$TAG" --repo "$REPO" \
+            --title "Rolling Release" \
+            --notes "$SHA"
+
+          # Upload all artifacts
+          for zip in artifacts/*/*.zip; do
+            gh release upload "$TAG" --repo "$REPO" --clobber "$zip"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: release
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -27,10 +31,12 @@ jobs:
             artifact_name: csgo-inventory-editor-macos-arm
 
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'push' && github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Cache cargo registry
         uses: actions/cache@v5
@@ -89,13 +95,15 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'push' && github.event.workflow_run.conclusion == 'success' }}
 
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -106,7 +114,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           TAG="release"
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A desktop application for editing [CS:GO GC](https://github.com/mikkokko/csgo_gc) inventory and config.
 
-Currently only supports Windows, but macOS and Linux versions are planned for future releases.
+Supports Windows and macOS. Linux support is planned for a future release.
 
 ## Features
 
@@ -33,8 +33,8 @@ Currently only supports Windows, but macOS and Linux versions are planned for fu
 
 - **Graphics Driver**: 
   - Windows: DirectX 12 (DX12)
-  - macOS: Metal (planned for future release)
-  - Linux: Vulkan (planned for future release)
+  - macOS: Metal
+  - Linux: Vulkan (planned for a future release)
 
 ## Building
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -4,7 +4,7 @@
 
 一款用于编辑 [CS:GO GC](https://github.com/mikkokko/csgo_gc) 库存和配置的桌面应用程序。
 
-目前只支持 Windows，但 macOS 和 Linux 版本计划在未来发布。
+支持 Windows 和 macOS。Linux 版本计划在未来发布。
 
 ## 功能特性
 
@@ -34,7 +34,7 @@
 
 - **图形驱动**：
   - Windows：DirectX 12 (DX12)
-  - macOS：Metal（计划未来发布）
+  - macOS：Metal
   - Linux：Vulkan（计划未来发布）
 
 ## 编译构建


### PR DESCRIPTION
## Summary

This PR adds automated CI builds and releases for macOS, covering both Intel (x86_64) and Apple Silicon (aarch64) architectures.

### Changes

- ****
  - Expands the build matrix to run on , , and .
  - Installs the correct Rust target on macOS runners.
  - Updates cache keys to include the target triple to prevent cross-arch cache collisions.

- ****
  - Adds parallel release builds for all three platforms.
  - Platform-specific packaging (PowerShell for Windows, shell/zip for macOS).
  - Introduces a  job that collects all artifacts and uploads them to the rolling release.

- **README / README_zh-CN**
  - Updates platform support wording: macOS is now supported, Linux remains planned.

### Verification

- , , and  pass locally on macOS (Apple Silicon).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified platform support: Windows and macOS are officially supported in the current release; Linux support is planned for a future release.
  * Updated system requirements with finalized graphics driver specifications for supported platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GT-610/csgo-gc-inventory-editor/pull/7)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->