### PR TITLE
fix(ci): avoid paid intel runner, build both macOS targets on macos-latest

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: macos-15-intel
+          - os: macos-latest
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact_name: csgo-inventory-editor-windows
-          - os: macos-15-intel
+          - os: macos-latest
             target: x86_64-apple-darwin
             artifact_name: csgo-inventory-editor-macos-intel
           - os: macos-latest
@@ -31,7 +31,7 @@ jobs:
             artifact_name: csgo-inventory-editor-macos-arm
 
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name == 'push' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -95,7 +95,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     permissions:
       contents: write


### PR DESCRIPTION
- Replace the paid macos-15-intel large runner with the free macos-latest runner for x86_64-apple-darwin builds (Rust target-based cross build).
- Keep both macOS matrix slots on macos-latest so the free arm64 runner handles both Apple Silicon and Intel via cross compilation, eliminating the long queue wait.
- Revert the event_name == 'push' guard that never evaluates to true under workflow_run events, restoring the original conclusion-only guard so the release jobs can actually execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS x86_64 build environment to use the latest available runner version for improved compatibility
  * Refined release workflow execution conditions to ensure successful build validation before publishing artifacts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GT-610/csgo-gc-inventory-editor/pull/8)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->