### PR TITLE
Add live RCON control for inventory editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ target/
 .vscode/
 *.code-workspace
 *.sublime-*
-.trae/
 
 # OS
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,3 @@ After code changes:
 - `src/ui/` - UI components
 - `src/app.rs` - Main application state/logic
 - `src/main.rs` - Entry point and event handling
-
-## Reference
-`.trae\references` contains referenceable project code, library source code, and documentation.

--- a/csgo_gc/editor/languages/en-US.ftl
+++ b/csgo_gc/editor/languages/en-US.ftl
@@ -6,6 +6,7 @@ page-settings = Settings
 
 # Sidebar
 sidebar-inventory = Inventory
+sidebar-rcon = RCON
 sidebar-settings = Settings
 
 # Settings Page
@@ -205,3 +206,47 @@ attr-232 = Spray Remaining
 attr-233 = Spray Color
 load-errors-help = Check that the required game data files (items_game.txt, language files) exist next to the executable in the csgo directory, or verify file permissions.
 load-errors-title = Failed to Load Game Data
+
+# Runtime Mode
+readonly-rcon-message = RCON is connected. inventory.txt and config.txt are read-only until you disconnect.
+
+# Config RCON
+appid-override = App ID override:
+config-rcon-title = Target GC RCON
+config-rcon-enabled = Enable RCON listener:
+config-rcon-bind-address = Bind address:
+config-rcon-port = Port:
+config-rcon-password = Password:
+config-log-output = Log output:
+config-rcon-restart-note = csgo_gc reads this configuration at load time. Restart or reload the target GC after changing RCON settings.
+
+# RCON Page
+rcon-title = RCON
+rcon-status-connected = Connected. Offline files are read-only.
+rcon-status-disconnected = Disconnected. Offline editing is available.
+rcon-address = Address:
+rcon-port = Port:
+rcon-password = Password:
+rcon-connect = Connect
+rcon-disconnect = Disconnect
+rcon-raw-command = Raw command
+rcon-send = Send
+rcon-ping = Ping
+rcon-status = Status
+rcon-help = Help
+rcon-clients = Clients
+rcon-refresh-inventory = Refresh Inventory
+rcon-give-item = Give Item
+rcon-defindex = DefIndex:
+rcon-count = Count:
+rcon-paint = Paint:
+rcon-seed = Seed:
+rcon-wear = Wear:
+rcon-stattrak = StatTrak:
+rcon-give = Give
+rcon-remove-item = Remove Item
+rcon-item-id = Item ID
+rcon-remove = Remove
+rcon-last-response = Last Response
+rcon-log = Log
+rcon-send-this-item = Send via RCON

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,7 @@ use crate::online_data::{
     DataProvider, OnlineGameData, fetch_online_data_with_progress, load_cached_data,
     save_cached_data,
 };
+use crate::rcon::RconClient;
 use crate::settings::{Settings, Theme};
 use eframe::egui;
 use egui_i18n::tr;
@@ -18,6 +19,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::mpsc::{self, Receiver};
+use std::time::Duration;
 
 // Type alias for select window items: (id, name, value, optional_color)
 pub type SelectWindowItem = (String, String, String, Option<String>);
@@ -216,7 +218,15 @@ impl ItemTemplate {
 pub enum Page {
     #[default]
     Inventory,
+    Rcon,
     Settings,
+}
+
+#[derive(Debug, Default, PartialEq, Clone, Copy)]
+pub enum RuntimeMode {
+    #[default]
+    OfflineEdit,
+    LiveRcon,
 }
 
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
@@ -269,6 +279,9 @@ pub struct CsgoInventoryEditor {
     online_data_receiver: Option<Receiver<OnlineDataFetchResult>>,
     pub current_page: Page,
     pub current_settings_page: SettingsPage,
+    pub runtime_mode: RuntimeMode,
+    pub rcon_ui: RconUiState,
+    pub rcon_client: Option<RconClient>,
     pub config: Config,
     pub status_message: Option<String>,
     cached_quality_names: Vec<(u32, String)>,
@@ -279,6 +292,51 @@ pub struct CsgoInventoryEditor {
     cached_item_display_names: RefCell<HashMap<u64, String>>,
     load_errors: Vec<String>,
     last_theme: Option<Theme>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RconUiState {
+    pub address: String,
+    pub port: u16,
+    pub password: String,
+    pub command_input: String,
+    pub give_def_index: u32,
+    pub give_count: u32,
+    pub give_level: u32,
+    pub give_quality: u32,
+    pub give_rarity: u32,
+    pub give_custom_name: String,
+    pub give_paint: String,
+    pub give_seed: String,
+    pub give_wear: String,
+    pub give_stattrak: String,
+    pub remove_item_id: String,
+    pub last_response: String,
+    pub log: Vec<String>,
+}
+
+impl Default for RconUiState {
+    fn default() -> Self {
+        Self {
+            address: "127.0.0.1".to_string(),
+            port: 37016,
+            password: String::new(),
+            command_input: String::new(),
+            give_def_index: 7,
+            give_count: 1,
+            give_level: 1,
+            give_quality: 4,
+            give_rarity: 0,
+            give_custom_name: String::new(),
+            give_paint: String::new(),
+            give_seed: String::new(),
+            give_wear: String::new(),
+            give_stattrak: String::new(),
+            remove_item_id: String::new(),
+            last_response: String::new(),
+            log: Vec::new(),
+        }
+    }
 }
 
 fn init_i18n(language: &str) {
@@ -425,6 +483,12 @@ impl CsgoInventoryEditor {
 
         let items_game = Arc::new(items_game);
         let translations = Arc::new(translations);
+        let rcon_ui = RconUiState {
+            address: settings.rcon.address.clone(),
+            port: settings.rcon.port,
+            password: settings.rcon.password.clone(),
+            ..RconUiState::default()
+        };
 
         let mut app = Self {
             inventory,
@@ -462,6 +526,9 @@ impl CsgoInventoryEditor {
             online_data_receiver: None,
             current_page: Page::default(),
             current_settings_page: SettingsPage::default(),
+            runtime_mode: RuntimeMode::default(),
+            rcon_ui,
+            rcon_client: None,
             config,
             status_message: None,
             cached_quality_names: Vec::new(),
@@ -576,6 +643,9 @@ impl CsgoInventoryEditor {
     }
 
     pub fn save_inventory(&mut self) -> Result<(), String> {
+        if self.is_live_rcon() {
+            return Err("RCON is connected; inventory.txt is read-only".to_string());
+        }
         if let Some(ref game_dir) = self.game_dir {
             let result = InventoryLoader::save_to_game_dir(&self.inventory, game_dir.path())
                 .map_err(|e| e.to_string());
@@ -589,11 +659,99 @@ impl CsgoInventoryEditor {
     }
 
     pub fn save_config(&mut self) -> Result<(), String> {
+        if self.is_live_rcon() {
+            return Err("RCON is connected; config.txt is read-only".to_string());
+        }
         if let Some(ref game_dir) = self.game_dir {
             let config_path = game_dir.path().join("csgo_gc").join("config.txt");
             ConfigLoader::save(&self.config, &config_path).map_err(|e| e.to_string())
         } else {
             Err("Game directory not found".to_string())
+        }
+    }
+
+    pub fn is_live_rcon(&self) -> bool {
+        self.runtime_mode == RuntimeMode::LiveRcon
+    }
+
+    pub fn connect_rcon(&mut self) {
+        self.settings.rcon.address = self.rcon_ui.address.clone();
+        self.settings.rcon.port = self.rcon_ui.port;
+        self.settings.rcon.password = self.rcon_ui.password.clone();
+        let _ = self.settings.save();
+
+        self.push_rcon_log(format!(
+            "Connecting to {}:{}...",
+            self.rcon_ui.address, self.rcon_ui.port
+        ));
+
+        match RconClient::connect(
+            &self.rcon_ui.address,
+            self.rcon_ui.port,
+            &self.rcon_ui.password,
+            Duration::from_secs(3),
+        ) {
+            Ok(client) => {
+                self.rcon_client = Some(client);
+                self.runtime_mode = RuntimeMode::LiveRcon;
+                self.push_rcon_log("Connected. Offline files are now read-only.".to_string());
+            }
+            Err(e) => {
+                self.rcon_client = None;
+                self.runtime_mode = RuntimeMode::OfflineEdit;
+                self.push_rcon_log(format!("Connect failed: {}", e));
+            }
+        }
+    }
+
+    pub fn disconnect_rcon(&mut self) {
+        self.rcon_client = None;
+        self.runtime_mode = RuntimeMode::OfflineEdit;
+        self.push_rcon_log("Disconnected. Offline editing is available.".to_string());
+    }
+
+    pub fn send_rcon_command(&mut self, command: &str) {
+        if command.trim().is_empty() {
+            return;
+        }
+
+        let response = if let Some(client) = self.rcon_client.as_mut() {
+            client.send_command(command.trim())
+        } else {
+            Err("RCON is not connected".to_string())
+        };
+
+        self.push_rcon_log(format!("> {}", command.trim()));
+        match response {
+            Ok(response) => {
+                self.rcon_ui.last_response = response.clone();
+                self.push_rcon_log(response);
+            }
+            Err(e) => {
+                self.rcon_ui.last_response = format!("ERR {}", e);
+                self.push_rcon_log(format!("ERR {}", e));
+                self.disconnect_rcon();
+            }
+        }
+    }
+
+    pub fn send_item_via_rcon(&mut self, item_id: u64) {
+        let Some(item) = self.inventory.items.iter().find(|item| item.id == item_id) else {
+            self.push_rcon_log(format!("ERR item {} not found", item_id));
+            return;
+        };
+
+        match crate::rcon::commands::build_give_item_command(item, 1) {
+            Ok(command) => self.send_rcon_command(&command),
+            Err(e) => self.push_rcon_log(format!("ERR {}", e)),
+        }
+    }
+
+    pub fn push_rcon_log(&mut self, message: String) {
+        self.rcon_ui.log.push(message);
+        if self.rcon_ui.log.len() > 200 {
+            let excess = self.rcon_ui.log.len() - 200;
+            self.rcon_ui.log.drain(0..excess);
         }
     }
 
@@ -974,6 +1132,9 @@ impl Default for CsgoInventoryEditor {
             online_data_receiver: None,
             current_page: Page::default(),
             current_settings_page: SettingsPage::default(),
+            runtime_mode: RuntimeMode::default(),
+            rcon_ui: RconUiState::default(),
+            rcon_client: None,
             config: Config::default(),
             status_message: None,
             cached_quality_names: Vec::new(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -700,7 +700,7 @@ impl CsgoInventoryEditor {
         self.settings.rcon.address = self.rcon_ui.address.clone();
         self.settings.rcon.port = self.rcon_ui.port;
         self.settings.rcon.password = self.rcon_ui.password.clone();
-        let _ = self.settings.save();
+        self.record_result(self.settings.save(), "save settings");
 
         let address = self.rcon_ui.address.clone();
         let port = self.rcon_ui.port;

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,6 +27,7 @@ pub type SelectWindowItems = Vec<SelectWindowItem>;
 
 // Type alias for online data fetch result: (data, timestamp, language)
 pub type OnlineDataFetchResult = Result<(OnlineGameData, String, String), String>;
+pub type RconConnectResult = Result<RconClient, String>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SelectWindowPurpose {
@@ -38,6 +39,8 @@ pub enum SelectWindowPurpose {
     SelectStickerKit,
     SelectGraffitiTint,
     AddAttribute,
+    RconItemDef,
+    RconPaintKit,
 }
 
 impl SelectWindowPurpose {
@@ -51,6 +54,8 @@ impl SelectWindowPurpose {
             SelectWindowPurpose::SelectStickerKit => "select_sticker_kit",
             SelectWindowPurpose::SelectGraffitiTint => "select_graffiti_tint",
             SelectWindowPurpose::AddAttribute => "add_attribute",
+            SelectWindowPurpose::RconItemDef => "rcon_item_def",
+            SelectWindowPurpose::RconPaintKit => "rcon_paint_kit",
         }
     }
 }
@@ -282,6 +287,7 @@ pub struct CsgoInventoryEditor {
     pub runtime_mode: RuntimeMode,
     pub rcon_ui: RconUiState,
     pub rcon_client: Option<RconClient>,
+    rcon_connect_receiver: Option<Receiver<RconConnectResult>>,
     pub config: Config,
     pub status_message: Option<String>,
     cached_quality_names: Vec<(u32, String)>,
@@ -529,6 +535,7 @@ impl CsgoInventoryEditor {
             runtime_mode: RuntimeMode::default(),
             rcon_ui,
             rcon_client: None,
+            rcon_connect_receiver: None,
             config,
             status_message: None,
             cached_quality_names: Vec::new(),
@@ -674,40 +681,70 @@ impl CsgoInventoryEditor {
         self.runtime_mode == RuntimeMode::LiveRcon
     }
 
+    pub fn is_connecting_rcon(&self) -> bool {
+        self.rcon_connect_receiver.is_some()
+    }
+
     pub fn connect_rcon(&mut self) {
+        if self.is_connecting_rcon() || self.is_live_rcon() {
+            return;
+        }
+
         self.settings.rcon.address = self.rcon_ui.address.clone();
         self.settings.rcon.port = self.rcon_ui.port;
         self.settings.rcon.password = self.rcon_ui.password.clone();
         let _ = self.settings.save();
+
+        let address = self.rcon_ui.address.clone();
+        let port = self.rcon_ui.port;
+        let password = self.rcon_ui.password.clone();
 
         self.push_rcon_log(format!(
             "Connecting to {}:{}...",
             self.rcon_ui.address, self.rcon_ui.port
         ));
 
-        match RconClient::connect(
-            &self.rcon_ui.address,
-            self.rcon_ui.port,
-            &self.rcon_ui.password,
-            Duration::from_secs(3),
-        ) {
-            Ok(client) => {
+        let (tx, rx) = mpsc::channel();
+        self.rcon_connect_receiver = Some(rx);
+        std::thread::spawn(move || {
+            let result = RconClient::connect(&address, port, &password, Duration::from_secs(3));
+            let _ = tx.send(result);
+        });
+    }
+
+    pub fn disconnect_rcon(&mut self) {
+        self.rcon_connect_receiver = None;
+        self.rcon_client = None;
+        self.runtime_mode = RuntimeMode::OfflineEdit;
+        self.push_rcon_log("Disconnected. Offline editing is available.".to_string());
+    }
+
+    pub fn check_rcon_connect_result(&mut self) {
+        let Some(receiver) = &self.rcon_connect_receiver else {
+            return;
+        };
+
+        match receiver.try_recv() {
+            Ok(Ok(client)) => {
+                self.rcon_connect_receiver = None;
                 self.rcon_client = Some(client);
                 self.runtime_mode = RuntimeMode::LiveRcon;
                 self.push_rcon_log("Connected. Offline files are now read-only.".to_string());
             }
-            Err(e) => {
+            Ok(Err(e)) => {
+                self.rcon_connect_receiver = None;
                 self.rcon_client = None;
                 self.runtime_mode = RuntimeMode::OfflineEdit;
                 self.push_rcon_log(format!("Connect failed: {}", e));
             }
+            Err(mpsc::TryRecvError::Empty) => {}
+            Err(mpsc::TryRecvError::Disconnected) => {
+                self.rcon_connect_receiver = None;
+                self.rcon_client = None;
+                self.runtime_mode = RuntimeMode::OfflineEdit;
+                self.push_rcon_log("Connect failed: worker disconnected".to_string());
+            }
         }
-    }
-
-    pub fn disconnect_rcon(&mut self) {
-        self.rcon_client = None;
-        self.runtime_mode = RuntimeMode::OfflineEdit;
-        self.push_rcon_log("Disconnected. Offline editing is available.".to_string());
     }
 
     pub fn send_rcon_command(&mut self, command: &str) {
@@ -1135,6 +1172,7 @@ impl Default for CsgoInventoryEditor {
             runtime_mode: RuntimeMode::default(),
             rcon_ui: RconUiState::default(),
             rcon_client: None,
+            rcon_connect_receiver: None,
             config: Config::default(),
             status_message: None,
             cached_quality_names: Vec::new(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,6 +28,7 @@ pub type SelectWindowItems = Vec<SelectWindowItem>;
 // Type alias for online data fetch result: (data, timestamp, language)
 pub type OnlineDataFetchResult = Result<(OnlineGameData, String, String), String>;
 pub type RconConnectResult = Result<RconClient, String>;
+pub type RconCommandResult = (RconClient, String, Result<String, String>);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SelectWindowPurpose {
@@ -288,6 +289,7 @@ pub struct CsgoInventoryEditor {
     pub rcon_ui: RconUiState,
     pub rcon_client: Option<RconClient>,
     rcon_connect_receiver: Option<Receiver<RconConnectResult>>,
+    rcon_command_receiver: Option<Receiver<RconCommandResult>>,
     pub config: Config,
     pub status_message: Option<String>,
     cached_quality_names: Vec<(u32, String)>,
@@ -536,6 +538,7 @@ impl CsgoInventoryEditor {
             rcon_ui,
             rcon_client: None,
             rcon_connect_receiver: None,
+            rcon_command_receiver: None,
             config,
             status_message: None,
             cached_quality_names: Vec::new(),
@@ -685,6 +688,10 @@ impl CsgoInventoryEditor {
         self.rcon_connect_receiver.is_some()
     }
 
+    pub fn is_sending_rcon_command(&self) -> bool {
+        self.rcon_command_receiver.is_some()
+    }
+
     pub fn connect_rcon(&mut self) {
         if self.is_connecting_rcon() || self.is_live_rcon() {
             return;
@@ -714,6 +721,7 @@ impl CsgoInventoryEditor {
 
     pub fn disconnect_rcon(&mut self) {
         self.rcon_connect_receiver = None;
+        self.rcon_command_receiver = None;
         self.rcon_client = None;
         self.runtime_mode = RuntimeMode::OfflineEdit;
         self.push_rcon_log("Disconnected. Offline editing is available.".to_string());
@@ -748,26 +756,60 @@ impl CsgoInventoryEditor {
     }
 
     pub fn send_rcon_command(&mut self, command: &str) {
-        if command.trim().is_empty() {
+        let command = command.trim();
+        if command.is_empty() {
             return;
         }
 
-        let response = if let Some(client) = self.rcon_client.as_mut() {
-            client.send_command(command.trim())
-        } else {
-            Err("RCON is not connected".to_string())
+        if self.is_sending_rcon_command() {
+            self.push_rcon_log("ERR RCON command already in progress".to_string());
+            return;
+        }
+
+        let Some(mut client) = self.rcon_client.take() else {
+            self.push_rcon_log("ERR RCON is not connected".to_string());
+            return;
         };
 
-        self.push_rcon_log(format!("> {}", command.trim()));
-        match response {
-            Ok(response) => {
-                self.rcon_ui.last_response = response.clone();
-                self.push_rcon_log(response);
+        let command = command.to_string();
+        self.push_rcon_log(format!("> {}", command));
+
+        let (tx, rx) = mpsc::channel();
+        self.rcon_command_receiver = Some(rx);
+        std::thread::spawn(move || {
+            let response = client.send_command(&command);
+            let _ = tx.send((client, command, response));
+        });
+    }
+
+    pub fn check_rcon_command_result(&mut self) {
+        let Some(receiver) = &self.rcon_command_receiver else {
+            return;
+        };
+
+        match receiver.try_recv() {
+            Ok((client, _command, response)) => {
+                self.rcon_command_receiver = None;
+                match response {
+                    Ok(response) => {
+                        self.rcon_client = Some(client);
+                        self.rcon_ui.last_response = response.clone();
+                        self.push_rcon_log(response);
+                    }
+                    Err(e) => {
+                        self.rcon_ui.last_response = format!("ERR {}", e);
+                        self.push_rcon_log(format!("ERR {}", e));
+                        self.rcon_client = None;
+                        self.runtime_mode = RuntimeMode::OfflineEdit;
+                    }
+                }
             }
-            Err(e) => {
-                self.rcon_ui.last_response = format!("ERR {}", e);
-                self.push_rcon_log(format!("ERR {}", e));
-                self.disconnect_rcon();
+            Err(mpsc::TryRecvError::Empty) => {}
+            Err(mpsc::TryRecvError::Disconnected) => {
+                self.rcon_command_receiver = None;
+                self.rcon_client = None;
+                self.runtime_mode = RuntimeMode::OfflineEdit;
+                self.push_rcon_log("ERR RCON command worker disconnected".to_string());
             }
         }
     }
@@ -1173,6 +1215,7 @@ impl Default for CsgoInventoryEditor {
             rcon_ui: RconUiState::default(),
             rcon_client: None,
             rcon_connect_receiver: None,
+            rcon_command_receiver: None,
             config: Config::default(),
             status_message: None,
             cached_quality_names: Vec::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 #[derive(Debug, Clone)]
 #[allow(clippy::derivable_impls)]
 pub struct Config {
+    pub appid_override: u32,
     pub competitive_rank: u32,
     pub competitive_wins: u32,
     pub wingman_rank: u32,
@@ -19,11 +20,17 @@ pub struct Config {
     pub player_cur_xp: u32,
     pub destroy_used_items: bool,
     pub show_csgo_gc_servers_only: bool,
+    pub rcon_enabled: bool,
+    pub rcon_bind_address: String,
+    pub rcon_port: u16,
+    pub rcon_password: String,
+    pub log_output: u32,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
+            appid_override: 4465480,
             competitive_rank: 18,
             competitive_wins: 666,
             wingman_rank: 18,
@@ -38,6 +45,11 @@ impl Default for Config {
             player_cur_xp: 4999,
             destroy_used_items: true,
             show_csgo_gc_servers_only: false,
+            rcon_enabled: false,
+            rcon_bind_address: "127.0.0.1".to_string(),
+            rcon_port: 37016,
+            rcon_password: String::new(),
+            log_output: 1,
         }
     }
 }
@@ -54,6 +66,9 @@ impl ConfigLoader {
 
         let mut config = Config::default();
 
+        if let Some(VdfValue::String(s)) = vdf.get("appid_override") {
+            config.appid_override = s.parse().unwrap_or(config.appid_override);
+        }
         if let Some(VdfValue::Object(ranks)) = vdf.get("ranks") {
             if let Some(VdfValue::String(s)) = ranks.get("competitive_rank") {
                 config.competitive_rank = s.parse().unwrap_or(config.competitive_rank);
@@ -99,6 +114,23 @@ impl ConfigLoader {
         if let Some(VdfValue::String(s)) = vdf.get("show_csgo_gc_servers_only") {
             config.show_csgo_gc_servers_only = s == "1";
         }
+        if let Some(VdfValue::Object(rcon)) = vdf.get("rcon") {
+            if let Some(VdfValue::String(s)) = rcon.get("enabled") {
+                config.rcon_enabled = s == "1";
+            }
+            if let Some(VdfValue::String(s)) = rcon.get("bind_address") {
+                config.rcon_bind_address = s.clone();
+            }
+            if let Some(VdfValue::String(s)) = rcon.get("port") {
+                config.rcon_port = s.parse().unwrap_or(config.rcon_port);
+            }
+            if let Some(VdfValue::String(s)) = rcon.get("password") {
+                config.rcon_password = s.clone();
+            }
+        }
+        if let Some(VdfValue::String(s)) = vdf.get("log_output") {
+            config.log_output = s.parse().unwrap_or(config.log_output);
+        }
 
         Ok(config)
     }
@@ -140,6 +172,10 @@ impl ConfigLoader {
         rarity_weights.insert("99".to_string(), VdfValue::String("1280".to_string()));
 
         let mut root = std::collections::HashMap::new();
+        root.insert(
+            "appid_override".to_string(),
+            VdfValue::String(config.appid_override.to_string()),
+        );
         root.insert("ranks".to_string(), VdfValue::Object(ranks));
         root.insert(
             "vac_banned".to_string(),
@@ -188,6 +224,33 @@ impl ConfigLoader {
             } else {
                 "0".to_string()
             }),
+        );
+
+        let mut rcon = std::collections::HashMap::new();
+        rcon.insert(
+            "enabled".to_string(),
+            VdfValue::String(if config.rcon_enabled {
+                "1".to_string()
+            } else {
+                "0".to_string()
+            }),
+        );
+        rcon.insert(
+            "bind_address".to_string(),
+            VdfValue::String(config.rcon_bind_address.clone()),
+        );
+        rcon.insert(
+            "port".to_string(),
+            VdfValue::String(config.rcon_port.to_string()),
+        );
+        rcon.insert(
+            "password".to_string(),
+            VdfValue::String(config.rcon_password.clone()),
+        );
+        root.insert("rcon".to_string(), VdfValue::Object(rcon));
+        root.insert(
+            "log_output".to_string(),
+            VdfValue::String(config.log_output.to_string()),
         );
 
         let content = VdfParser::to_string(&VdfValue::Object(root));

--- a/src/inventory/vdf.rs
+++ b/src/inventory/vdf.rs
@@ -156,6 +156,7 @@ impl VdfParser {
                     });
                 } else if is_config_root {
                     let config_field_order = vec![
+                        "appid_override",
                         "ranks",
                         "vac_banned",
                         "cmd_friendly",
@@ -165,6 +166,9 @@ impl VdfParser {
                         "player_cur_xp",
                         "rarity_weights",
                         "destroy_used_items",
+                        "show_csgo_gc_servers_only",
+                        "rcon",
+                        "log_output",
                     ];
                     keys.sort_by(|a, b| {
                         let a_idx = config_field_order

--- a/src/main.rs
+++ b/src/main.rs
@@ -431,6 +431,7 @@ impl eframe::App for CsgoInventoryEditor {
                     {
                         self.rcon_ui.give_def_index = def_index;
                         self.rcon_ui.give_paint.clear();
+                        self.rcon_ui.give_rarity = 0;
                     }
                     self.close_select_window();
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod core;
 pub mod inventory;
 pub mod online_data;
+pub mod rcon;
 pub mod settings;
 pub mod ui;
 
@@ -39,6 +40,12 @@ impl eframe::App for CsgoInventoryEditor {
             self.load_online_data();
         }
 
+        if self.is_live_rcon() {
+            self.pending_add_item = false;
+            self.show_template_modal = false;
+            self.delete_confirm_item_id = None;
+        }
+
         egui::Panel::left("sidebar")
             .exact_size(120.0)
             .show_inside(ui, |ui| {
@@ -48,6 +55,9 @@ impl eframe::App for CsgoInventoryEditor {
         egui::CentralPanel::default().show_inside(ui, |ui| match self.current_page {
             Page::Inventory => {
                 ui::draw_inventory_page(ui, self);
+            }
+            Page::Rcon => {
+                ui::draw_rcon_page(ui, self);
             }
             Page::Settings => {
                 ui::draw_settings_page(ui, self);

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,11 @@ impl eframe::App for CsgoInventoryEditor {
             ctx.request_repaint_after(std::time::Duration::from_millis(100));
         }
 
+        if self.is_sending_rcon_command() {
+            self.check_rcon_command_result();
+            ctx.request_repaint_after(std::time::Duration::from_millis(100));
+        }
+
         // Load online data only once when flag is set and not already fetching
         if self.is_loading_online && !self.is_fetching_online_data() {
             self.load_online_data();

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,11 @@ impl eframe::App for CsgoInventoryEditor {
             ctx.request_repaint_after(std::time::Duration::from_millis(100));
         }
 
+        if self.is_connecting_rcon() {
+            self.check_rcon_connect_result();
+            ctx.request_repaint_after(std::time::Duration::from_millis(100));
+        }
+
         // Load online data only once when flag is set and not already fetching
         if self.is_loading_online && !self.is_fetching_online_data() {
             self.load_online_data();
@@ -411,6 +416,29 @@ impl eframe::App for CsgoInventoryEditor {
                         edit_state
                             .attributes
                             .insert(attr_id, get_attribute_default_value(attr_id).to_string());
+                    }
+                    self.close_select_window();
+                }
+
+                Some(SelectWindowPurpose::RconItemDef) => {
+                    if let Some((value, _, _, _)) = self.select_window_items.get(selected_idx)
+                        && let Ok(def_index) = value.parse::<u32>()
+                    {
+                        self.rcon_ui.give_def_index = def_index;
+                        self.rcon_ui.give_paint.clear();
+                    }
+                    self.close_select_window();
+                }
+
+                Some(SelectWindowPurpose::RconPaintKit) => {
+                    if let Some((value, _, _, _)) = self.select_window_items.get(selected_idx) {
+                        self.rcon_ui.give_paint = value.clone();
+                        if let Ok(paint_index) = value.parse::<u32>()
+                            && let Some(rarity) =
+                                self.get_skin_rarity(self.rcon_ui.give_def_index, paint_index)
+                        {
+                            self.rcon_ui.give_rarity = rarity;
+                        }
                     }
                     self.close_select_window();
                 }

--- a/src/rcon/client.rs
+++ b/src/rcon/client.rs
@@ -2,9 +2,12 @@ use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::time::Duration;
 
+const SERVERDATA_RESPONSE_VALUE: i32 = 0;
 const SERVERDATA_EXECCOMMAND: i32 = 2;
 const SERVERDATA_AUTH_RESPONSE: i32 = 2;
 const SERVERDATA_AUTH: i32 = 3;
+const MIN_PACKET_SIZE: i32 = 10;
+const MAX_PACKET_SIZE: i32 = 4096;
 
 #[derive(Debug)]
 struct RconPacket {
@@ -69,13 +72,35 @@ impl RconClient {
     pub fn send_command(&mut self, command: &str) -> Result<String, String> {
         let id = self.next_id;
         self.next_id = self.next_id.saturating_add(1);
+        let terminator_id = self.next_id;
+        self.next_id = self.next_id.saturating_add(1);
         write_packet(&mut self.stream, id, SERVERDATA_EXECCOMMAND, command)?;
+        write_packet(&mut self.stream, terminator_id, SERVERDATA_EXECCOMMAND, "")?;
 
-        let packet = read_packet(&mut self.stream)?;
-        if packet.id != id && packet.id != 0 {
-            return Err(format!("Unexpected RCON response id {}", packet.id));
+        let mut body = String::new();
+        loop {
+            let packet = read_packet(&mut self.stream)?;
+            if packet.id == terminator_id {
+                if packet.packet_type != SERVERDATA_RESPONSE_VALUE {
+                    return Err(format!(
+                        "Unexpected RCON terminator packet type {}",
+                        packet.packet_type
+                    ));
+                }
+                break;
+            }
+            if packet.id != id {
+                return Err(format!("Unexpected RCON response id {}", packet.id));
+            }
+            if packet.packet_type != SERVERDATA_RESPONSE_VALUE {
+                return Err(format!(
+                    "Unexpected RCON response packet type {}",
+                    packet.packet_type
+                ));
+            }
+            body.push_str(&packet.body);
         }
-        Ok(packet.body)
+        Ok(body)
     }
 }
 
@@ -108,7 +133,7 @@ fn read_packet(stream: &mut TcpStream) -> Result<RconPacket, String> {
         .read_exact(&mut size_bytes)
         .map_err(|e| format!("Failed to read RCON packet size: {}", e))?;
     let size = i32::from_le_bytes(size_bytes);
-    if size < 10 {
+    if !(MIN_PACKET_SIZE..=MAX_PACKET_SIZE).contains(&size) {
         return Err(format!("Invalid RCON packet size {}", size));
     }
 

--- a/src/rcon/client.rs
+++ b/src/rcon/client.rs
@@ -1,0 +1,130 @@
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+const SERVERDATA_EXECCOMMAND: i32 = 2;
+const SERVERDATA_AUTH_RESPONSE: i32 = 2;
+const SERVERDATA_AUTH: i32 = 3;
+
+#[derive(Debug)]
+struct RconPacket {
+    id: i32,
+    packet_type: i32,
+    body: String,
+}
+
+pub struct RconClient {
+    stream: TcpStream,
+    next_id: i32,
+}
+
+impl RconClient {
+    pub fn connect(
+        address: &str,
+        port: u16,
+        password: &str,
+        timeout: Duration,
+    ) -> Result<Self, String> {
+        let mut addrs = (address, port)
+            .to_socket_addrs()
+            .map_err(|e| format!("Failed to resolve address: {}", e))?;
+
+        let socket_addr = addrs
+            .next()
+            .ok_or_else(|| "No socket address resolved".to_string())?;
+
+        let mut stream =
+            TcpStream::connect_timeout(&socket_addr, timeout).map_err(|e| e.to_string())?;
+        stream
+            .set_read_timeout(Some(timeout))
+            .map_err(|e| e.to_string())?;
+        stream
+            .set_write_timeout(Some(timeout))
+            .map_err(|e| e.to_string())?;
+
+        let auth_id = 1;
+        write_packet(&mut stream, auth_id, SERVERDATA_AUTH, password)?;
+
+        let mut authenticated = false;
+        for _ in 0..2 {
+            let packet = read_packet(&mut stream)?;
+            if packet.packet_type == SERVERDATA_AUTH_RESPONSE {
+                if packet.id == -1 {
+                    return Err("RCON authentication failed".to_string());
+                }
+                if packet.id == auth_id {
+                    authenticated = true;
+                    break;
+                }
+            }
+        }
+
+        if !authenticated {
+            return Err("RCON authentication response not received".to_string());
+        }
+
+        Ok(Self { stream, next_id: 2 })
+    }
+
+    pub fn send_command(&mut self, command: &str) -> Result<String, String> {
+        let id = self.next_id;
+        self.next_id = self.next_id.saturating_add(1);
+        write_packet(&mut self.stream, id, SERVERDATA_EXECCOMMAND, command)?;
+
+        let packet = read_packet(&mut self.stream)?;
+        if packet.id != id && packet.id != 0 {
+            return Err(format!("Unexpected RCON response id {}", packet.id));
+        }
+        Ok(packet.body)
+    }
+}
+
+fn write_packet(
+    stream: &mut TcpStream,
+    id: i32,
+    packet_type: i32,
+    body: &str,
+) -> Result<(), String> {
+    let body_bytes = body.as_bytes();
+    let size = 4 + 4 + body_bytes.len() + 2;
+    if size > i32::MAX as usize {
+        return Err("RCON packet is too large".to_string());
+    }
+
+    let mut bytes = Vec::with_capacity(4 + size);
+    bytes.extend_from_slice(&(size as i32).to_le_bytes());
+    bytes.extend_from_slice(&id.to_le_bytes());
+    bytes.extend_from_slice(&packet_type.to_le_bytes());
+    bytes.extend_from_slice(body_bytes);
+    bytes.push(0);
+    bytes.push(0);
+
+    stream.write_all(&bytes).map_err(|e| e.to_string())
+}
+
+fn read_packet(stream: &mut TcpStream) -> Result<RconPacket, String> {
+    let mut size_bytes = [0u8; 4];
+    stream
+        .read_exact(&mut size_bytes)
+        .map_err(|e| format!("Failed to read RCON packet size: {}", e))?;
+    let size = i32::from_le_bytes(size_bytes);
+    if size < 10 {
+        return Err(format!("Invalid RCON packet size {}", size));
+    }
+
+    let mut payload = vec![0u8; size as usize];
+    stream
+        .read_exact(&mut payload)
+        .map_err(|e| format!("Failed to read RCON packet payload: {}", e))?;
+
+    let id = i32::from_le_bytes(payload[0..4].try_into().expect("packet id bytes"));
+    let packet_type = i32::from_le_bytes(payload[4..8].try_into().expect("packet type bytes"));
+    let body_bytes = &payload[8..payload.len().saturating_sub(2)];
+    let body = String::from_utf8_lossy(body_bytes).to_string();
+
+    Ok(RconPacket {
+        id,
+        packet_type,
+        body,
+    })
+}

--- a/src/rcon/commands.rs
+++ b/src/rcon/commands.rs
@@ -1,0 +1,121 @@
+use crate::inventory::{Item, ItemAttribute};
+
+pub fn build_give_item_command(item: &Item, count: u32) -> Result<String, String> {
+    if !(1..=100).contains(&count) {
+        return Err("count must be between 1 and 100".to_string());
+    }
+
+    let mut parts = vec!["give_item".to_string(), item.def_index.to_string()];
+    if count != 1 {
+        parts.push(count.to_string());
+    }
+
+    parts.push(format!("level={}", item.level));
+    parts.push(format!("quality={}", item.quality));
+    parts.push(format!("rarity={}", item.rarity));
+
+    if let Some(custom_name) = &item.custom_name
+        && !custom_name.is_empty()
+    {
+        parts.push(format!("name={}", quote_value(custom_name)));
+    }
+
+    push_u32_attr(
+        &mut parts,
+        item,
+        ItemAttribute::SkinPaintIndex.id(),
+        "paint",
+    )?;
+    push_u32_attr(&mut parts, item, ItemAttribute::SkinPaintSeed.id(), "seed")?;
+    push_float_attr(&mut parts, item, ItemAttribute::SkinPaintWear.id(), "wear")?;
+    push_u32_attr(
+        &mut parts,
+        item,
+        ItemAttribute::StatTrakCount.id(),
+        "stattrak",
+    )?;
+    push_u32_attr(&mut parts, item, ItemAttribute::MusicID.id(), "music")?;
+    push_u32_attr(
+        &mut parts,
+        item,
+        ItemAttribute::SprayColor.id(),
+        "spray_color",
+    )?;
+    push_u32_attr(
+        &mut parts,
+        item,
+        ItemAttribute::SprayRemain.id(),
+        "spray_remaining",
+    )?;
+
+    for slot in 0..=5 {
+        let base = 113 + slot * 4;
+        push_u32_attr(&mut parts, item, base, &format!("sticker{}", slot))?;
+        push_float_attr(&mut parts, item, base + 1, &format!("sticker{}_wear", slot))?;
+        push_float_attr(
+            &mut parts,
+            item,
+            base + 2,
+            &format!("sticker{}_scale", slot),
+        )?;
+        push_float_attr(
+            &mut parts,
+            item,
+            base + 3,
+            &format!("sticker{}_rotation", slot),
+        )?;
+    }
+
+    Ok(parts.join(" "))
+}
+
+pub fn build_remove_item_command(item_id: u64) -> String {
+    format!("remove_item {}", item_id)
+}
+
+pub fn quote_value(value: &str) -> String {
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{}\"", escaped)
+}
+
+fn push_u32_attr(
+    parts: &mut Vec<String>,
+    item: &Item,
+    attr_id: u32,
+    key: &str,
+) -> Result<(), String> {
+    if let Some(value) = item.attributes.get(&attr_id) {
+        let parsed = parse_u32_attr(value, key)?;
+        parts.push(format!("{}={}", key, parsed));
+    }
+    Ok(())
+}
+
+fn push_float_attr(
+    parts: &mut Vec<String>,
+    item: &Item,
+    attr_id: u32,
+    key: &str,
+) -> Result<(), String> {
+    if let Some(value) = item.attributes.get(&attr_id) {
+        let parsed = value
+            .parse::<f32>()
+            .map_err(|_| format!("invalid parameter {}", key))?;
+        parts.push(format!("{}={}", key, parsed));
+    }
+    Ok(())
+}
+
+fn parse_u32_attr(value: &str, key: &str) -> Result<u32, String> {
+    if let Ok(parsed) = value.parse::<u32>() {
+        return Ok(parsed);
+    }
+
+    let parsed_float = value
+        .parse::<f32>()
+        .map_err(|_| format!("invalid parameter {}", key))?;
+    if parsed_float < 0.0 || parsed_float.fract() != 0.0 || parsed_float > u32::MAX as f32 {
+        return Err(format!("invalid parameter {}", key));
+    }
+    Ok(parsed_float as u32)
+}

--- a/src/rcon/mod.rs
+++ b/src/rcon/mod.rs
@@ -1,0 +1,4 @@
+pub mod client;
+pub mod commands;
+
+pub use client::RconClient;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -68,6 +68,25 @@ pub struct Settings {
     pub mirror_site: MirrorSite,
     #[serde(default)]
     pub last_online_update: Option<String>,
+    #[serde(default)]
+    pub rcon: RconClientSettings,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RconClientSettings {
+    pub address: String,
+    pub port: u16,
+    pub password: String,
+}
+
+impl Default for RconClientSettings {
+    fn default() -> Self {
+        Self {
+            address: "127.0.0.1".to_string(),
+            port: 37016,
+            password: String::new(),
+        }
+    }
 }
 
 impl Default for Settings {
@@ -77,6 +96,7 @@ impl Default for Settings {
             theme: Theme::default(),
             mirror_site: MirrorSite::default(),
             last_online_update: None,
+            rcon: RconClientSettings::default(),
         }
     }
 }

--- a/src/ui/inventory_page.rs
+++ b/src/ui/inventory_page.rs
@@ -31,6 +31,12 @@ pub fn draw_inventory_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
         });
     } else {
         egui::Panel::top("toolbar").show_inside(ui, |ui| {
+            if state.is_live_rcon() {
+                ui.label(
+                    egui::RichText::new(tr!("readonly-rcon-message")).color(egui::Color32::YELLOW),
+                );
+                ui.separator();
+            }
             crate::ui::draw_toolbar(ui, state);
         });
 

--- a/src/ui/inventory_page.rs
+++ b/src/ui/inventory_page.rs
@@ -32,8 +32,13 @@ pub fn draw_inventory_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     } else {
         egui::Panel::top("toolbar").show_inside(ui, |ui| {
             if state.is_live_rcon() {
+                let message = if state.current_language == "zh-Hans" {
+                    "RCON 已连接。断开前 inventory.txt 和 config.txt 为只读。"
+                } else {
+                    "RCON is connected. inventory.txt and config.txt are read-only until you disconnect."
+                };
                 ui.label(
-                    egui::RichText::new(tr!("readonly-rcon-message")).color(egui::Color32::YELLOW),
+                    egui::RichText::new(message).color(egui::Color32::YELLOW),
                 );
                 ui.separator();
             }

--- a/src/ui/item_detail.rs
+++ b/src/ui/item_detail.rs
@@ -18,7 +18,9 @@ pub fn draw_item_detail_windows(
     let open_windows = state.open_item_windows.clone();
     let mut windows_to_close: Vec<u64> = Vec::new();
     let mut pending_save_item_id: Option<u64> = None;
+    let mut pending_send_item_id: Option<u64> = None;
     let mut pending_open_select_window: Option<SelectWindowItems> = None;
+    let read_only = state.is_live_rcon();
 
     for item_id in open_windows {
         let Some(item_idx) = state.get_item_index(item_id) else {
@@ -77,11 +79,17 @@ pub fn draw_item_detail_windows(
             .open(&mut window_open)
             .show(ctx, |ui| {
                 ui.horizontal(|ui| {
-                    if ui.button(tr!("btn-save")).clicked() {
+                    if ui
+                        .add_enabled(!read_only, egui::Button::new(tr!("btn-save")))
+                        .clicked()
+                    {
                         pending_save_item_id = Some(item_id);
                     }
                     ui.add_space(10.0);
-                    if ui.button(tr!("btn-save-close")).clicked() {
+                    if ui
+                        .add_enabled(!read_only, egui::Button::new(tr!("btn-save-close")))
+                        .clicked()
+                    {
                         pending_save_item_id = Some(item_id);
                         pending_save_and_close = true;
                     }
@@ -90,8 +98,18 @@ pub fn draw_item_detail_windows(
                         windows_to_close.push(item_id);
                     }
                     ui.add_space(10.0);
-                    if ui.button(tr!("btn-delete")).clicked() {
+                    if ui
+                        .add_enabled(!read_only, egui::Button::new(tr!("btn-delete")))
+                        .clicked()
+                    {
                         state.delete_confirm_item_id = Some(item_id);
+                    }
+                    ui.add_space(10.0);
+                    if ui
+                        .add_enabled(read_only, egui::Button::new(tr!("rcon-send-this-item")))
+                        .clicked()
+                    {
+                        pending_send_item_id = Some(item_id);
                     }
 
                     if has_unsaved_changes {
@@ -129,7 +147,10 @@ pub fn draw_item_detail_windows(
                                 ui.label(item_base_name.to_string());
                                 ui.label(format!("({})", item_def_index));
                                 ui.add_space(10.0);
-                                if ui.button(tr!("btn-select")).clicked() {
+                                if ui
+                                    .add_enabled(!read_only, egui::Button::new(tr!("btn-select")))
+                                    .clicked()
+                                {
                                     let items = state.create_item_select_list();
                                     *pending_select_window_items = Some(items);
                                     should_open_select_window = true;
@@ -144,7 +165,10 @@ pub fn draw_item_detail_windows(
                             ui.label(tr!("level"));
                         });
                         row.col(|ui| {
-                            ui.add(egui::DragValue::new(&mut edit_state.level).range(0..=100));
+                            ui.add_enabled(
+                                !read_only,
+                                egui::DragValue::new(&mut edit_state.level).range(0..=100),
+                            );
                         });
                     });
 
@@ -160,20 +184,22 @@ pub fn draw_item_detail_windows(
                                 .map(|(_, name)| name.clone())
                                 .unwrap_or_else(|| format!("Unknown ({})", edit_state.quality));
 
-                            egui::ComboBox::from_id_salt(format!("quality_combo_{}", item_id))
-                                .selected_text(format!(
-                                    "{} ({})",
-                                    selected_name, edit_state.quality
-                                ))
-                                .show_ui(ui, |ui| {
-                                    for (value, name) in all_qualities {
-                                        ui.selectable_value(
-                                            &mut edit_state.quality,
-                                            *value,
-                                            format!("{} ({})", name, value),
-                                        );
-                                    }
-                                });
+                            ui.add_enabled_ui(!read_only, |ui| {
+                                egui::ComboBox::from_id_salt(format!("quality_combo_{}", item_id))
+                                    .selected_text(format!(
+                                        "{} ({})",
+                                        selected_name, edit_state.quality
+                                    ))
+                                    .show_ui(ui, |ui| {
+                                        for (value, name) in all_qualities {
+                                            ui.selectable_value(
+                                                &mut edit_state.quality,
+                                                *value,
+                                                format!("{} ({})", name, value),
+                                            );
+                                        }
+                                    });
+                            });
                         });
                     });
 
@@ -190,17 +216,22 @@ pub fn draw_item_detail_windows(
                                 .map(|(_, n)| n.clone())
                                 .unwrap_or_else(|| format!("Unknown ({})", edit_state.rarity));
 
-                            egui::ComboBox::from_id_salt(format!("rarity_combo_{}", item_id))
-                                .selected_text(format!("{} ({})", selected_name, edit_state.rarity))
-                                .show_ui(ui, |ui| {
-                                    for (value, name) in rarity_names {
-                                        ui.selectable_value(
-                                            &mut edit_state.rarity,
-                                            *value,
-                                            format!("{} ({})", name, value),
-                                        );
-                                    }
-                                });
+                            ui.add_enabled_ui(!read_only, |ui| {
+                                egui::ComboBox::from_id_salt(format!("rarity_combo_{}", item_id))
+                                    .selected_text(format!(
+                                        "{} ({})",
+                                        selected_name, edit_state.rarity
+                                    ))
+                                    .show_ui(ui, |ui| {
+                                        for (value, name) in rarity_names {
+                                            ui.selectable_value(
+                                                &mut edit_state.rarity,
+                                                *value,
+                                                format!("{} ({})", name, value),
+                                            );
+                                        }
+                                    });
+                            });
                         });
                     });
 
@@ -209,7 +240,10 @@ pub fn draw_item_detail_windows(
                             ui.label(tr!("custom-name"));
                         });
                         row.col(|ui| {
-                            ui.text_edit_singleline(&mut edit_state.custom_name);
+                            ui.add_enabled(
+                                !read_only,
+                                egui::TextEdit::singleline(&mut edit_state.custom_name),
+                            );
                         });
                     });
                 });
@@ -222,7 +256,7 @@ pub fn draw_item_detail_windows(
                         .any(|attr_id| !edit_state.attributes.contains_key(attr_id));
                     if ui
                         .add_enabled(
-                            can_add_attribute,
+                            can_add_attribute && !read_only,
                             egui::Button::new(tr!("btn-add-attribute")),
                         )
                         .clicked()
@@ -298,7 +332,13 @@ pub fn draw_item_detail_windows(
                                         ui.horizontal(|ui| {
                                             ui.label(attr_value_display);
                                             ui.add_space(10.0);
-                                            if ui.button(tr!("btn-select")).clicked() {
+                                            if ui
+                                                .add_enabled(
+                                                    !read_only,
+                                                    egui::Button::new(tr!("btn-select")),
+                                                )
+                                                .clicked()
+                                            {
                                                 state.pending_paint_kit_select =
                                                     Some((item_id_for_edit, item_def_index));
                                             }
@@ -307,7 +347,13 @@ pub fn draw_item_detail_windows(
                                         ui.horizontal(|ui| {
                                             ui.label(attr_value_display);
                                             ui.add_space(10.0);
-                                            if ui.button(tr!("btn-select")).clicked() {
+                                            if ui
+                                                .add_enabled(
+                                                    !read_only,
+                                                    egui::Button::new(tr!("btn-select")),
+                                                )
+                                                .clicked()
+                                            {
                                                 state.pending_music_def_select =
                                                     Some(item_id_for_edit);
                                             }
@@ -322,7 +368,13 @@ pub fn draw_item_detail_windows(
                                         ui.horizontal(|ui| {
                                             ui.label(attr_value_display);
                                             ui.add_space(10.0);
-                                            if ui.button(tr!("btn-select")).clicked() {
+                                            if ui
+                                                .add_enabled(
+                                                    !read_only,
+                                                    egui::Button::new(tr!("btn-select")),
+                                                )
+                                                .clicked()
+                                            {
                                                 state.pending_sticker_kit_select =
                                                     Some((item_id_for_edit, *attr_id));
                                             }
@@ -331,7 +383,13 @@ pub fn draw_item_detail_windows(
                                         ui.horizontal(|ui| {
                                             ui.label(attr_value_display);
                                             ui.add_space(10.0);
-                                            if ui.button(tr!("btn-select")).clicked() {
+                                            if ui
+                                                .add_enabled(
+                                                    !read_only,
+                                                    egui::Button::new(tr!("btn-select")),
+                                                )
+                                                .clicked()
+                                            {
                                                 state.pending_graffiti_tint_select =
                                                     Some(item_id_for_edit);
                                             }
@@ -341,11 +399,20 @@ pub fn draw_item_detail_windows(
                                             .attributes
                                             .entry(*attr_id)
                                             .or_insert_with(|| edit_value.clone());
-                                        ui.text_edit_singleline(value_mut);
+                                        ui.add_enabled(
+                                            !read_only,
+                                            egui::TextEdit::singleline(value_mut),
+                                        );
                                     }
                                 });
                                 row.col(|ui| {
-                                    if ui.button(tr!("btn-delete-attribute")).clicked() {
+                                    if ui
+                                        .add_enabled(
+                                            !read_only,
+                                            egui::Button::new(tr!("btn-delete-attribute")),
+                                        )
+                                        .clicked()
+                                    {
                                         edit_state.attributes.remove(attr_id);
                                     }
                                 });
@@ -376,7 +443,12 @@ pub fn draw_item_detail_windows(
         *select_window_open = true;
     }
 
-    if let Some(item_id) = pending_save_item_id
+    if let Some(item_id) = pending_send_item_id {
+        state.send_item_via_rcon(item_id);
+    }
+
+    if !read_only
+        && let Some(item_id) = pending_save_item_id
         && let Some(edit_state) = state.edit_item_states.get(&item_id)
         && let Some(item_idx) = state.get_item_index(item_id)
     {
@@ -392,7 +464,7 @@ pub fn draw_item_detail_windows(
         item.attributes = edit_state.attributes.clone();
     }
 
-    if pending_save_item_id.is_some() {
+    if pending_save_item_id.is_some() && !read_only {
         let result = state.save_inventory();
         state.record_result(result, "save inventory");
     }
@@ -402,7 +474,7 @@ pub fn draw_item_detail_windows(
         state.edit_item_states.remove(&window_id);
     }
 
-    if let Some(item_id) = state.delete_confirm_item_id {
+    if !read_only && let Some(item_id) = state.delete_confirm_item_id {
         let item_name = state
             .inventory
             .items
@@ -449,7 +521,7 @@ pub fn draw_item_detail_windows(
         }
     }
 
-    if state.show_template_modal {
+    if !read_only && state.show_template_modal {
         let mut template_confirmed = false;
 
         egui::Modal::new(egui::Id::new("template_modal")).show(ctx, |ui| {

--- a/src/ui/item_detail.rs
+++ b/src/ui/item_detail.rs
@@ -106,7 +106,14 @@ pub fn draw_item_detail_windows(
                     }
                     ui.add_space(10.0);
                     if ui
-                        .add_enabled(read_only, egui::Button::new(tr!("rcon-send-this-item")))
+                        .add_enabled(
+                            read_only,
+                            egui::Button::new(if state.current_language == "zh-Hans" {
+                                "通过 RCON 发送"
+                            } else {
+                                "Send via RCON"
+                            }),
+                        )
                         .clicked()
                     {
                         pending_send_item_id = Some(item_id);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 pub mod inventory_page;
 pub mod item_detail;
 pub mod item_grid;
+pub mod rcon_page;
 pub mod select_window;
 pub mod settings_page;
 pub mod sidebar;
@@ -9,6 +10,7 @@ pub mod toolbar;
 pub use inventory_page::draw_inventory_page;
 pub use item_detail::draw_item_detail_windows;
 pub use item_grid::draw_item_grid;
+pub use rcon_page::draw_rcon_page;
 pub use select_window::draw_select_window;
 pub use settings_page::draw_settings_page;
 pub use sidebar::draw_sidebar;

--- a/src/ui/rcon_page.rs
+++ b/src/ui/rcon_page.rs
@@ -6,15 +6,16 @@ use egui_i18n::tr;
 pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     let connected = state.is_live_rcon();
     let connecting = state.is_connecting_rcon();
-    let can_send = connected && !connecting;
+    let sending = state.is_sending_rcon_command();
+    let can_send = connected && !connecting && !sending;
     let mut actions = RconPageActions::default();
 
     egui::ScrollArea::vertical().show(ui, |ui| {
-        ui.heading("RCON");
+        ui.heading(label(state, RconLabel::Title));
         ui.add_space(8.0);
-        draw_status(ui, connected, connecting);
+        draw_status(ui, state, connected, connecting, sending);
         ui.separator();
-        draw_connection(ui, state, connected, connecting, &mut actions);
+        draw_connection(ui, state, connected, connecting, sending, &mut actions);
         ui.separator();
         draw_raw_command(ui, state, can_send, &mut actions);
         ui.separator();
@@ -40,13 +41,131 @@ struct RconPageActions {
     select_paint: bool,
 }
 
-fn draw_status(ui: &mut egui::Ui, connected: bool, connecting: bool) {
+#[derive(Clone, Copy)]
+enum RconLabel {
+    Title,
+    Connecting,
+    Sending,
+    Connected,
+    Disconnected,
+    Address,
+    Port,
+    Password,
+    Connect,
+    Disconnect,
+    RawCommand,
+    Send,
+    Ping,
+    Status,
+    Help,
+    Clients,
+    RefreshInventory,
+    GiveItem,
+    Item,
+    CountLevel,
+    Paint,
+    SeedWearStatTrak,
+    Seed,
+    Wear,
+    StatTrak,
+    Give,
+    RemoveItem,
+    ItemId,
+    Remove,
+    LastResponse,
+    Log,
+    SelectItem,
+    SelectPaintKit,
+}
+
+fn label(state: &CsgoInventoryEditor, label: RconLabel) -> &'static str {
+    let zh = state.current_language == "zh-Hans";
+    match (zh, label) {
+        (_, RconLabel::Title) => "RCON",
+        (true, RconLabel::Connecting) => "\u{6b63}\u{5728}\u{8fde}\u{63a5}...",
+        (false, RconLabel::Connecting) => "Connecting...",
+        (true, RconLabel::Sending) => "\u{6b63}\u{5728}\u{53d1}\u{9001}\u{547d}\u{4ee4}...",
+        (false, RconLabel::Sending) => "Sending command...",
+        (true, RconLabel::Connected) => {
+            "\u{5df2}\u{8fde}\u{63a5}\u{3002}\u{79bb}\u{7ebf}\u{6587}\u{4ef6}\u{4e3a}\u{53ea}\u{8bfb}\u{3002}"
+        }
+        (false, RconLabel::Connected) => "Connected. Offline files are read-only.",
+        (true, RconLabel::Disconnected) => {
+            "\u{672a}\u{8fde}\u{63a5}\u{3002}\u{53ef}\u{4ee5}\u{8fdb}\u{884c}\u{79bb}\u{7ebf}\u{7f16}\u{8f91}\u{3002}"
+        }
+        (false, RconLabel::Disconnected) => "Disconnected. Offline editing is available.",
+        (true, RconLabel::Address) => "\u{5730}\u{5740}:",
+        (false, RconLabel::Address) => "Address:",
+        (true, RconLabel::Port) => "\u{7aef}\u{53e3}:",
+        (false, RconLabel::Port) => "Port:",
+        (true, RconLabel::Password) => "\u{5bc6}\u{7801}:",
+        (false, RconLabel::Password) => "Password:",
+        (true, RconLabel::Connect) => "\u{8fde}\u{63a5}",
+        (false, RconLabel::Connect) => "Connect",
+        (true, RconLabel::Disconnect) => "\u{65ad}\u{5f00}",
+        (false, RconLabel::Disconnect) => "Disconnect",
+        (true, RconLabel::RawCommand) => "\u{539f}\u{59cb}\u{547d}\u{4ee4}",
+        (false, RconLabel::RawCommand) => "Raw command",
+        (true, RconLabel::Send) => "\u{53d1}\u{9001}",
+        (false, RconLabel::Send) => "Send",
+        (_, RconLabel::Ping) => "Ping",
+        (true, RconLabel::Status) => "\u{72b6}\u{6001}",
+        (false, RconLabel::Status) => "Status",
+        (true, RconLabel::Help) => "\u{5e2e}\u{52a9}",
+        (false, RconLabel::Help) => "Help",
+        (true, RconLabel::Clients) => "\u{5ba2}\u{6237}\u{7aef}",
+        (false, RconLabel::Clients) => "Clients",
+        (true, RconLabel::RefreshInventory) => "\u{5237}\u{65b0}\u{5e93}\u{5b58}",
+        (false, RconLabel::RefreshInventory) => "Refresh Inventory",
+        (true, RconLabel::GiveItem) => "\u{53d1}\u{9001}\u{7269}\u{54c1}",
+        (false, RconLabel::GiveItem) => "Give Item",
+        (true, RconLabel::Item) => "\u{7269}\u{54c1}:",
+        (false, RconLabel::Item) => "Item:",
+        (true, RconLabel::CountLevel) => "\u{6570}\u{91cf} / \u{7b49}\u{7ea7}:",
+        (false, RconLabel::CountLevel) => "Count / Level:",
+        (true, RconLabel::Paint) => "\u{6d82}\u{88c5}:",
+        (false, RconLabel::Paint) => "Paint:",
+        (true, RconLabel::SeedWearStatTrak) => "\u{6a21}\u{677f} / \u{78e8}\u{635f} / StatTrak:",
+        (false, RconLabel::SeedWearStatTrak) => "Seed / Wear / StatTrak:",
+        (true, RconLabel::Seed) => "\u{6a21}\u{677f}",
+        (false, RconLabel::Seed) => "Seed",
+        (true, RconLabel::Wear) => "\u{78e8}\u{635f}",
+        (false, RconLabel::Wear) => "Wear",
+        (_, RconLabel::StatTrak) => "StatTrak",
+        (true, RconLabel::Give) => "\u{53d1}\u{9001}\u{7269}\u{54c1}",
+        (false, RconLabel::Give) => "Give",
+        (true, RconLabel::RemoveItem) => "\u{79fb}\u{9664}\u{7269}\u{54c1}",
+        (false, RconLabel::RemoveItem) => "Remove Item",
+        (true, RconLabel::ItemId) => "\u{7269}\u{54c1} ID",
+        (false, RconLabel::ItemId) => "Item ID",
+        (true, RconLabel::Remove) => "\u{79fb}\u{9664}",
+        (false, RconLabel::Remove) => "Remove",
+        (true, RconLabel::LastResponse) => "\u{6700}\u{540e}\u{54cd}\u{5e94}",
+        (false, RconLabel::LastResponse) => "Last Response",
+        (true, RconLabel::Log) => "\u{65e5}\u{5fd7}",
+        (false, RconLabel::Log) => "Log",
+        (true, RconLabel::SelectItem) => "\u{9009}\u{62e9}\u{7269}\u{54c1}",
+        (false, RconLabel::SelectItem) => "Select Item",
+        (true, RconLabel::SelectPaintKit) => "\u{9009}\u{62e9}\u{6d82}\u{88c5}",
+        (false, RconLabel::SelectPaintKit) => "Select Paint Kit",
+    }
+}
+
+fn draw_status(
+    ui: &mut egui::Ui,
+    state: &CsgoInventoryEditor,
+    connected: bool,
+    connecting: bool,
+    sending: bool,
+) {
     let status = if connecting {
-        "Connecting..."
+        label(state, RconLabel::Connecting)
+    } else if sending {
+        label(state, RconLabel::Sending)
     } else if connected {
-        "Connected. Offline files are read-only."
+        label(state, RconLabel::Connected)
     } else {
-        "Disconnected. Offline editing is available."
+        label(state, RconLabel::Disconnected)
     };
     ui.label(status);
 }
@@ -56,6 +175,7 @@ fn draw_connection(
     state: &mut CsgoInventoryEditor,
     connected: bool,
     connecting: bool,
+    sending: bool,
     actions: &mut RconPageActions,
 ) {
     ui.add_enabled_ui(!connected && !connecting, |ui| {
@@ -63,18 +183,18 @@ fn draw_connection(
             .num_columns(2)
             .spacing([12.0, 8.0])
             .show(ui, |ui| {
-                ui.label("Address:");
+                ui.label(label(state, RconLabel::Address));
                 ui.add(
                     egui::TextEdit::singleline(&mut state.rcon_ui.address)
                         .desired_width(ui.available_width().min(420.0)),
                 );
                 ui.end_row();
 
-                ui.label("Port:");
+                ui.label(label(state, RconLabel::Port));
                 ui.add(egui::DragValue::new(&mut state.rcon_ui.port).range(1..=65535));
                 ui.end_row();
 
-                ui.label("Password:");
+                ui.label(label(state, RconLabel::Password));
                 ui.add(
                     egui::TextEdit::singleline(&mut state.rcon_ui.password)
                         .password(true)
@@ -86,18 +206,24 @@ fn draw_connection(
 
     ui.horizontal_wrapped(|ui| {
         if ui
-            .add_enabled(!connected && !connecting, egui::Button::new("Connect"))
+            .add_enabled(
+                !connected && !connecting,
+                egui::Button::new(label(state, RconLabel::Connect)),
+            )
             .clicked()
         {
             actions.connect = true;
         }
         if ui
-            .add_enabled(connected || connecting, egui::Button::new("Disconnect"))
+            .add_enabled(
+                connected || connecting || sending,
+                egui::Button::new(label(state, RconLabel::Disconnect)),
+            )
             .clicked()
         {
             actions.disconnect = true;
         }
-        if connecting {
+        if connecting || sending {
             ui.spinner();
         }
     });
@@ -109,7 +235,7 @@ fn draw_raw_command(
     can_send: bool,
     actions: &mut RconPageActions,
 ) {
-    ui.label("Raw command");
+    ui.label(label(state, RconLabel::RawCommand));
     ui.horizontal(|ui| {
         let input_width = (ui.available_width() - 72.0).max(160.0);
         ui.add_enabled(
@@ -117,7 +243,7 @@ fn draw_raw_command(
             egui::TextEdit::singleline(&mut state.rcon_ui.command_input).desired_width(input_width),
         );
         if ui
-            .add_enabled(can_send, egui::Button::new("Send"))
+            .add_enabled(can_send, egui::Button::new(label(state, RconLabel::Send)))
             .clicked()
         {
             actions.send_raw = true;
@@ -126,11 +252,14 @@ fn draw_raw_command(
 
     ui.horizontal_wrapped(|ui| {
         for (label, command) in [
-            ("Ping", "ping"),
-            ("Status", "status"),
-            ("Help", "help"),
-            ("Clients", "clients"),
-            ("Refresh Inventory", "refresh_inventory"),
+            (label(state, RconLabel::Ping), "ping"),
+            (label(state, RconLabel::Status), "status"),
+            (label(state, RconLabel::Help), "help"),
+            (label(state, RconLabel::Clients), "clients"),
+            (
+                label(state, RconLabel::RefreshInventory),
+                "refresh_inventory",
+            ),
         ] {
             if ui.add_enabled(can_send, egui::Button::new(label)).clicked() {
                 actions.quick_command = Some(command);
@@ -145,13 +274,13 @@ fn draw_give_item(
     can_send: bool,
     actions: &mut RconPageActions,
 ) {
-    ui.label("Give Item");
+    ui.label(label(state, RconLabel::GiveItem));
     ui.add_enabled_ui(can_send, |ui| {
         egui::Grid::new("rcon_give_grid")
             .num_columns(2)
             .spacing([12.0, 8.0])
             .show(ui, |ui| {
-                ui.label("Item:");
+                ui.label(label(state, RconLabel::Item));
                 ui.horizontal_wrapped(|ui| {
                     ui.label(selected_item_label(state));
                     if ui.button(tr!("btn-select")).clicked() {
@@ -160,7 +289,7 @@ fn draw_give_item(
                 });
                 ui.end_row();
 
-                ui.label("Count / Level:");
+                ui.label(label(state, RconLabel::CountLevel));
                 ui.horizontal_wrapped(|ui| {
                     ui.add(egui::DragValue::new(&mut state.rcon_ui.give_count).range(1..=100));
                     ui.label(tr!("level"));
@@ -183,7 +312,7 @@ fn draw_give_item(
                 );
                 ui.end_row();
 
-                ui.label("Paint:");
+                ui.label(label(state, RconLabel::Paint));
                 ui.horizontal_wrapped(|ui| {
                     ui.label(selected_paint_label(state));
                     if ui.button(tr!("btn-select")).clicked() {
@@ -192,16 +321,28 @@ fn draw_give_item(
                 });
                 ui.end_row();
 
-                ui.label("Seed / Wear / StatTrak:");
+                ui.label(label(state, RconLabel::SeedWearStatTrak));
                 ui.horizontal_wrapped(|ui| {
-                    labeled_text(ui, "Seed", &mut state.rcon_ui.give_seed);
-                    labeled_text(ui, "Wear", &mut state.rcon_ui.give_wear);
-                    labeled_text(ui, "StatTrak", &mut state.rcon_ui.give_stattrak);
+                    labeled_text(
+                        ui,
+                        label(state, RconLabel::Seed),
+                        &mut state.rcon_ui.give_seed,
+                    );
+                    labeled_text(
+                        ui,
+                        label(state, RconLabel::Wear),
+                        &mut state.rcon_ui.give_wear,
+                    );
+                    labeled_text(
+                        ui,
+                        label(state, RconLabel::StatTrak),
+                        &mut state.rcon_ui.give_stattrak,
+                    );
                 });
                 ui.end_row();
             });
 
-        if ui.button("Give").clicked() {
+        if ui.button(label(state, RconLabel::Give)).clicked() {
             actions.send_give = true;
         }
     });
@@ -268,16 +409,17 @@ fn draw_remove_item(
     can_send: bool,
     actions: &mut RconPageActions,
 ) {
-    ui.label("Remove Item");
+    ui.label(label(state, RconLabel::RemoveItem));
+    let item_id_hint = label(state, RconLabel::ItemId);
     ui.horizontal_wrapped(|ui| {
         ui.add_enabled(
             can_send,
             egui::TextEdit::singleline(&mut state.rcon_ui.remove_item_id)
-                .hint_text("Item ID")
+                .hint_text(item_id_hint)
                 .desired_width(ui.available_width().min(420.0)),
         );
         if ui
-            .add_enabled(can_send, egui::Button::new("Remove"))
+            .add_enabled(can_send, egui::Button::new(label(state, RconLabel::Remove)))
             .clicked()
         {
             actions.remove = true;
@@ -286,11 +428,11 @@ fn draw_remove_item(
 }
 
 fn draw_response_and_log(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
-    ui.label("Last Response");
+    ui.label(label(state, RconLabel::LastResponse));
     ui.monospace(&state.rcon_ui.last_response);
     ui.separator();
 
-    egui::CollapsingHeader::new("Log")
+    egui::CollapsingHeader::new(label(state, RconLabel::Log))
         .default_open(false)
         .show(ui, |ui| {
             egui::ScrollArea::vertical()
@@ -305,8 +447,6 @@ fn draw_response_and_log(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
 }
 
 fn handle_actions(state: &mut CsgoInventoryEditor, actions: RconPageActions) {
-    let language = state.current_language.clone();
-
     if actions.connect {
         state.connect_rcon();
     }
@@ -317,7 +457,7 @@ fn handle_actions(state: &mut CsgoInventoryEditor, actions: RconPageActions) {
         let items = state.create_item_select_list();
         state.open_select_window(
             SelectWindowPurpose::RconItemDef,
-            text(&language, "选择物品", "Select Item").to_string(),
+            label(state, RconLabel::SelectItem).to_string(),
             tr!("header-item-id").to_string(),
             tr!("header-item-name").to_string(),
             items,
@@ -327,7 +467,7 @@ fn handle_actions(state: &mut CsgoInventoryEditor, actions: RconPageActions) {
         let items = state.create_skin_select_list_for_weapon(state.rcon_ui.give_def_index);
         state.open_select_window(
             SelectWindowPurpose::RconPaintKit,
-            text(&language, "选择涂装", "Select Paint Kit").to_string(),
+            label(state, RconLabel::SelectPaintKit).to_string(),
             tr!("header-paintkit-id").to_string(),
             tr!("header-paintkit-name").to_string(),
             items,
@@ -429,8 +569,4 @@ fn push_optional_f32(parts: &mut Vec<String>, key: &str, value: &str) -> Result<
         .map_err(|_| format!("invalid parameter {}", key))?;
     parts.push(format!("{}={}", key, parsed));
     Ok(())
-}
-
-fn text<'a>(language: &str, zh: &'a str, en: &'a str) -> &'a str {
-    if language.starts_with("zh") { zh } else { en }
 }

--- a/src/ui/rcon_page.rs
+++ b/src/ui/rcon_page.rs
@@ -4,242 +4,316 @@ use eframe::egui;
 use egui_i18n::tr;
 
 pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
-    let language = state.current_language.clone();
     let connected = state.is_live_rcon();
     let connecting = state.is_connecting_rcon();
     let can_send = connected && !connecting;
-    let mut connect_clicked = false;
-    let mut disconnect_clicked = false;
-    let mut send_raw_clicked = false;
-    let mut quick_command: Option<&'static str> = None;
-    let mut send_give_clicked = false;
-    let mut remove_clicked = false;
-    let mut select_item_clicked = false;
-    let mut select_paint_clicked = false;
+    let mut actions = RconPageActions::default();
 
-    ui.heading("RCON");
-    ui.add_space(8.0);
-
-    ui.horizontal(|ui| {
-        let status = if connecting {
-            text(&language, "正在连接...", "Connecting...")
-        } else if connected {
-            text(
-                &language,
-                "已连接，离线文件为只读。",
-                "Connected. Offline files are read-only.",
-            )
-        } else {
-            text(
-                &language,
-                "未连接，可以进行离线编辑。",
-                "Disconnected. Offline editing is available.",
-            )
-        };
-        ui.label(status);
+    egui::ScrollArea::vertical().show(ui, |ui| {
+        ui.heading("RCON");
+        ui.add_space(8.0);
+        draw_status(ui, connected, connecting);
+        ui.separator();
+        draw_connection(ui, state, connected, connecting, &mut actions);
+        ui.separator();
+        draw_raw_command(ui, state, can_send, &mut actions);
+        ui.separator();
+        draw_give_item(ui, state, can_send, &mut actions);
+        ui.separator();
+        draw_remove_item(ui, state, can_send, &mut actions);
+        ui.separator();
+        draw_response_and_log(ui, state);
     });
 
-    ui.separator();
+    handle_actions(state, actions);
+}
 
+#[derive(Default)]
+struct RconPageActions {
+    connect: bool,
+    disconnect: bool,
+    send_raw: bool,
+    quick_command: Option<&'static str>,
+    send_give: bool,
+    remove: bool,
+    select_item: bool,
+    select_paint: bool,
+}
+
+fn draw_status(ui: &mut egui::Ui, connected: bool, connecting: bool) {
+    let status = if connecting {
+        "Connecting..."
+    } else if connected {
+        "Connected. Offline files are read-only."
+    } else {
+        "Disconnected. Offline editing is available."
+    };
+    ui.label(status);
+}
+
+fn draw_connection(
+    ui: &mut egui::Ui,
+    state: &mut CsgoInventoryEditor,
+    connected: bool,
+    connecting: bool,
+    actions: &mut RconPageActions,
+) {
     ui.add_enabled_ui(!connected && !connecting, |ui| {
-        ui.horizontal(|ui| {
-            ui.label(text(&language, "地址:", "Address:"));
-            ui.text_edit_singleline(&mut state.rcon_ui.address);
-            ui.label(text(&language, "端口:", "Port:"));
-            ui.add(egui::DragValue::new(&mut state.rcon_ui.port).range(1..=65535));
-        });
-        ui.horizontal(|ui| {
-            ui.label(text(&language, "密码:", "Password:"));
-            ui.add(egui::TextEdit::singleline(&mut state.rcon_ui.password).password(true));
-        });
+        egui::Grid::new("rcon_connection_grid")
+            .num_columns(2)
+            .spacing([12.0, 8.0])
+            .show(ui, |ui| {
+                ui.label("Address:");
+                ui.add(
+                    egui::TextEdit::singleline(&mut state.rcon_ui.address)
+                        .desired_width(ui.available_width().min(420.0)),
+                );
+                ui.end_row();
+
+                ui.label("Port:");
+                ui.add(egui::DragValue::new(&mut state.rcon_ui.port).range(1..=65535));
+                ui.end_row();
+
+                ui.label("Password:");
+                ui.add(
+                    egui::TextEdit::singleline(&mut state.rcon_ui.password)
+                        .password(true)
+                        .desired_width(ui.available_width().min(420.0)),
+                );
+                ui.end_row();
+            });
     });
 
-    ui.horizontal(|ui| {
+    ui.horizontal_wrapped(|ui| {
         if ui
-            .add_enabled(
-                !connected && !connecting,
-                egui::Button::new(text(&language, "连接", "Connect")),
-            )
+            .add_enabled(!connected && !connecting, egui::Button::new("Connect"))
             .clicked()
         {
-            connect_clicked = true;
+            actions.connect = true;
         }
         if ui
-            .add_enabled(
-                connected || connecting,
-                egui::Button::new(text(&language, "断开", "Disconnect")),
-            )
+            .add_enabled(connected || connecting, egui::Button::new("Disconnect"))
             .clicked()
         {
-            disconnect_clicked = true;
+            actions.disconnect = true;
         }
         if connecting {
             ui.spinner();
         }
     });
+}
 
-    ui.separator();
-    ui.label(text(&language, "原始命令", "Raw command"));
+fn draw_raw_command(
+    ui: &mut egui::Ui,
+    state: &mut CsgoInventoryEditor,
+    can_send: bool,
+    actions: &mut RconPageActions,
+) {
+    ui.label("Raw command");
     ui.horizontal(|ui| {
+        let input_width = (ui.available_width() - 72.0).max(160.0);
         ui.add_enabled(
             can_send,
-            egui::TextEdit::singleline(&mut state.rcon_ui.command_input)
-                .desired_width(f32::INFINITY),
+            egui::TextEdit::singleline(&mut state.rcon_ui.command_input).desired_width(input_width),
         );
         if ui
-            .add_enabled(can_send, egui::Button::new(text(&language, "发送", "Send")))
+            .add_enabled(can_send, egui::Button::new("Send"))
             .clicked()
         {
-            send_raw_clicked = true;
+            actions.send_raw = true;
         }
     });
 
-    ui.horizontal(|ui| {
+    ui.horizontal_wrapped(|ui| {
         for (label, command) in [
             ("Ping", "ping"),
-            (text(&language, "状态", "Status"), "status"),
-            (text(&language, "帮助", "Help"), "help"),
-            (text(&language, "客户端", "Clients"), "clients"),
-            (
-                text(&language, "刷新库存", "Refresh Inventory"),
-                "refresh_inventory",
-            ),
+            ("Status", "status"),
+            ("Help", "help"),
+            ("Clients", "clients"),
+            ("Refresh Inventory", "refresh_inventory"),
         ] {
             if ui.add_enabled(can_send, egui::Button::new(label)).clicked() {
-                quick_command = Some(command);
+                actions.quick_command = Some(command);
             }
         }
     });
+}
 
-    ui.separator();
-    ui.label(text(&language, "发送物品", "Give Item"));
+fn draw_give_item(
+    ui: &mut egui::Ui,
+    state: &mut CsgoInventoryEditor,
+    can_send: bool,
+    actions: &mut RconPageActions,
+) {
+    ui.label("Give Item");
     ui.add_enabled_ui(can_send, |ui| {
-        ui.horizontal(|ui| {
-            ui.label(text(&language, "物品:", "Item:"));
-            ui.label(selected_item_label(state));
-            if ui.button(tr!("btn-select")).clicked() {
-                select_item_clicked = true;
-            }
-            ui.label(text(&language, "数量:", "Count:"));
-            ui.add(egui::DragValue::new(&mut state.rcon_ui.give_count).range(1..=100));
-            ui.label(tr!("level"));
-            ui.add(egui::DragValue::new(&mut state.rcon_ui.give_level).range(0..=100));
-        });
-
-        ui.horizontal(|ui| {
-            ui.label(tr!("quality-id"));
-            let selected_quality = state
-                .get_cached_quality_names()
-                .iter()
-                .find(|(value, _)| *value == state.rcon_ui.give_quality)
-                .map(|(_, name)| name.clone())
-                .unwrap_or_else(|| format!("Unknown ({})", state.rcon_ui.give_quality));
-            let qualities = state.get_cached_quality_names().to_vec();
-            egui::ComboBox::from_id_salt("rcon_quality_combo")
-                .selected_text(format!(
-                    "{} ({})",
-                    selected_quality, state.rcon_ui.give_quality
-                ))
-                .show_ui(ui, |ui| {
-                    for (value, name) in qualities {
-                        ui.selectable_value(
-                            &mut state.rcon_ui.give_quality,
-                            value,
-                            format!("{} ({})", name, value),
-                        );
+        egui::Grid::new("rcon_give_grid")
+            .num_columns(2)
+            .spacing([12.0, 8.0])
+            .show(ui, |ui| {
+                ui.label("Item:");
+                ui.horizontal_wrapped(|ui| {
+                    ui.label(selected_item_label(state));
+                    if ui.button(tr!("btn-select")).clicked() {
+                        actions.select_item = true;
                     }
                 });
+                ui.end_row();
 
-            ui.label(tr!("rarity"));
-            let selected_rarity = state
-                .get_cached_rarity_names()
-                .iter()
-                .find(|(value, _)| *value == state.rcon_ui.give_rarity)
-                .map(|(_, name)| name.clone())
-                .unwrap_or_else(|| format!("Unknown ({})", state.rcon_ui.give_rarity));
-            let rarities = state.get_cached_rarity_names().to_vec();
-            egui::ComboBox::from_id_salt("rcon_rarity_combo")
-                .selected_text(format!(
-                    "{} ({})",
-                    selected_rarity, state.rcon_ui.give_rarity
-                ))
-                .show_ui(ui, |ui| {
-                    for (value, name) in rarities {
-                        ui.selectable_value(
-                            &mut state.rcon_ui.give_rarity,
-                            value,
-                            format!("{} ({})", name, value),
-                        );
+                ui.label("Count / Level:");
+                ui.horizontal_wrapped(|ui| {
+                    ui.add(egui::DragValue::new(&mut state.rcon_ui.give_count).range(1..=100));
+                    ui.label(tr!("level"));
+                    ui.add(egui::DragValue::new(&mut state.rcon_ui.give_level).range(0..=100));
+                });
+                ui.end_row();
+
+                ui.label(tr!("quality-id"));
+                draw_quality_combo(ui, state);
+                ui.end_row();
+
+                ui.label(tr!("rarity"));
+                draw_rarity_combo(ui, state);
+                ui.end_row();
+
+                ui.label(tr!("custom-name"));
+                ui.add(
+                    egui::TextEdit::singleline(&mut state.rcon_ui.give_custom_name)
+                        .desired_width(ui.available_width().min(520.0)),
+                );
+                ui.end_row();
+
+                ui.label("Paint:");
+                ui.horizontal_wrapped(|ui| {
+                    ui.label(selected_paint_label(state));
+                    if ui.button(tr!("btn-select")).clicked() {
+                        actions.select_paint = true;
                     }
                 });
-        });
+                ui.end_row();
 
-        ui.horizontal(|ui| {
-            ui.label(tr!("custom-name"));
-            ui.text_edit_singleline(&mut state.rcon_ui.give_custom_name);
-        });
+                ui.label("Seed / Wear / StatTrak:");
+                ui.horizontal_wrapped(|ui| {
+                    labeled_text(ui, "Seed", &mut state.rcon_ui.give_seed);
+                    labeled_text(ui, "Wear", &mut state.rcon_ui.give_wear);
+                    labeled_text(ui, "StatTrak", &mut state.rcon_ui.give_stattrak);
+                });
+                ui.end_row();
+            });
 
-        ui.horizontal(|ui| {
-            ui.label(text(&language, "涂装:", "Paint:"));
-            ui.label(selected_paint_label(state));
-            if ui.button(tr!("btn-select")).clicked() {
-                select_paint_clicked = true;
-            }
-            ui.label(text(&language, "模板:", "Seed:"));
-            ui.text_edit_singleline(&mut state.rcon_ui.give_seed);
-            ui.label(text(&language, "磨损:", "Wear:"));
-            ui.text_edit_singleline(&mut state.rcon_ui.give_wear);
-            ui.label("StatTrak:");
-            ui.text_edit_singleline(&mut state.rcon_ui.give_stattrak);
-        });
-
-        if ui.button(text(&language, "发送物品", "Give")).clicked() {
-            send_give_clicked = true;
+        if ui.button("Give").clicked() {
+            actions.send_give = true;
         }
     });
+}
 
-    ui.separator();
-    ui.label(text(&language, "移除物品", "Remove Item"));
-    ui.horizontal(|ui| {
+fn draw_quality_combo(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
+    let selected_quality = state
+        .get_cached_quality_names()
+        .iter()
+        .find(|(value, _)| *value == state.rcon_ui.give_quality)
+        .map(|(_, name)| name.clone())
+        .unwrap_or_else(|| format!("Unknown ({})", state.rcon_ui.give_quality));
+    let qualities = state.get_cached_quality_names().to_vec();
+    egui::ComboBox::from_id_salt("rcon_quality_combo")
+        .width(ui.available_width().min(320.0))
+        .selected_text(format!(
+            "{} ({})",
+            selected_quality, state.rcon_ui.give_quality
+        ))
+        .show_ui(ui, |ui| {
+            for (value, name) in qualities {
+                ui.selectable_value(
+                    &mut state.rcon_ui.give_quality,
+                    value,
+                    format!("{} ({})", name, value),
+                );
+            }
+        });
+}
+
+fn draw_rarity_combo(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
+    let selected_rarity = state
+        .get_cached_rarity_names()
+        .iter()
+        .find(|(value, _)| *value == state.rcon_ui.give_rarity)
+        .map(|(_, name)| name.clone())
+        .unwrap_or_else(|| format!("Unknown ({})", state.rcon_ui.give_rarity));
+    let rarities = state.get_cached_rarity_names().to_vec();
+    egui::ComboBox::from_id_salt("rcon_rarity_combo")
+        .width(ui.available_width().min(320.0))
+        .selected_text(format!(
+            "{} ({})",
+            selected_rarity, state.rcon_ui.give_rarity
+        ))
+        .show_ui(ui, |ui| {
+            for (value, name) in rarities {
+                ui.selectable_value(
+                    &mut state.rcon_ui.give_rarity,
+                    value,
+                    format!("{} ({})", name, value),
+                );
+            }
+        });
+}
+
+fn labeled_text(ui: &mut egui::Ui, label: &str, value: &mut String) {
+    ui.label(format!("{}:", label));
+    ui.add(egui::TextEdit::singleline(value).desired_width(120.0));
+}
+
+fn draw_remove_item(
+    ui: &mut egui::Ui,
+    state: &mut CsgoInventoryEditor,
+    can_send: bool,
+    actions: &mut RconPageActions,
+) {
+    ui.label("Remove Item");
+    ui.horizontal_wrapped(|ui| {
         ui.add_enabled(
             can_send,
-            egui::TextEdit::singleline(&mut state.rcon_ui.remove_item_id).hint_text(text(
-                &language,
-                "物品 ID",
-                "Item ID",
-            )),
+            egui::TextEdit::singleline(&mut state.rcon_ui.remove_item_id)
+                .hint_text("Item ID")
+                .desired_width(ui.available_width().min(420.0)),
         );
         if ui
-            .add_enabled(
-                can_send,
-                egui::Button::new(text(&language, "移除", "Remove")),
-            )
+            .add_enabled(can_send, egui::Button::new("Remove"))
             .clicked()
         {
-            remove_clicked = true;
+            actions.remove = true;
         }
     });
+}
 
-    ui.separator();
-    ui.label(text(&language, "最后响应", "Last Response"));
+fn draw_response_and_log(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
+    ui.label("Last Response");
     ui.monospace(&state.rcon_ui.last_response);
-    ui.add_space(8.0);
-    ui.label(text(&language, "日志", "Log"));
-    egui::ScrollArea::vertical()
-        .stick_to_bottom(true)
-        .show(ui, |ui| {
-            for line in &state.rcon_ui.log {
-                ui.monospace(line);
-            }
-        });
+    ui.separator();
 
-    if connect_clicked {
+    egui::CollapsingHeader::new("Log")
+        .default_open(false)
+        .show(ui, |ui| {
+            egui::ScrollArea::vertical()
+                .max_height(180.0)
+                .stick_to_bottom(true)
+                .show(ui, |ui| {
+                    for line in &state.rcon_ui.log {
+                        ui.monospace(line);
+                    }
+                });
+        });
+}
+
+fn handle_actions(state: &mut CsgoInventoryEditor, actions: RconPageActions) {
+    let language = state.current_language.clone();
+
+    if actions.connect {
         state.connect_rcon();
     }
-    if disconnect_clicked {
+    if actions.disconnect {
         state.disconnect_rcon();
     }
-    if select_item_clicked {
+    if actions.select_item {
         let items = state.create_item_select_list();
         state.open_select_window(
             SelectWindowPurpose::RconItemDef,
@@ -249,7 +323,7 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
             items,
         );
     }
-    if select_paint_clicked {
+    if actions.select_paint {
         let items = state.create_skin_select_list_for_weapon(state.rcon_ui.give_def_index);
         state.open_select_window(
             SelectWindowPurpose::RconPaintKit,
@@ -259,20 +333,20 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
             items,
         );
     }
-    if send_raw_clicked {
+    if actions.send_raw {
         let command = state.rcon_ui.command_input.clone();
         state.send_rcon_command(&command);
     }
-    if let Some(command) = quick_command {
+    if let Some(command) = actions.quick_command {
         state.send_rcon_command(command);
     }
-    if send_give_clicked {
+    if actions.send_give {
         match build_manual_give_command(state) {
             Ok(command) => state.send_rcon_command(&command),
             Err(e) => state.push_rcon_log(format!("ERR {}", e)),
         }
     }
-    if remove_clicked {
+    if actions.remove {
         match state.rcon_ui.remove_item_id.trim().parse::<u64>() {
             Ok(item_id) => {
                 let command = crate::rcon::commands::build_remove_item_command(item_id);
@@ -357,6 +431,6 @@ fn push_optional_f32(parts: &mut Vec<String>, key: &str, value: &str) -> Result<
     Ok(())
 }
 
-fn text(language: &str, zh: &'static str, en: &'static str) -> &'static str {
-    if language == "zh-Hans" { zh } else { en }
+fn text<'a>(language: &str, zh: &'a str, en: &'a str) -> &'a str {
+    if language.starts_with("zh") { zh } else { en }
 }

--- a/src/ui/rcon_page.rs
+++ b/src/ui/rcon_page.rs
@@ -1,22 +1,29 @@
-use crate::app::CsgoInventoryEditor;
+use crate::app::{CsgoInventoryEditor, SelectWindowPurpose};
+use crate::inventory::get_attribute_value_display_name;
 use eframe::egui;
 use egui_i18n::tr;
 
 pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     let language = state.current_language.clone();
     let connected = state.is_live_rcon();
+    let connecting = state.is_connecting_rcon();
+    let can_send = connected && !connecting;
     let mut connect_clicked = false;
     let mut disconnect_clicked = false;
     let mut send_raw_clicked = false;
     let mut quick_command: Option<&'static str> = None;
     let mut send_give_clicked = false;
     let mut remove_clicked = false;
+    let mut select_item_clicked = false;
+    let mut select_paint_clicked = false;
 
-    ui.heading(text(&language, "RCON", "RCON"));
+    ui.heading("RCON");
     ui.add_space(8.0);
 
     ui.horizontal(|ui| {
-        let status = if connected {
+        let status = if connecting {
+            text(&language, "正在连接...", "Connecting...")
+        } else if connected {
             text(
                 &language,
                 "已连接，离线文件为只读。",
@@ -34,7 +41,7 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
 
     ui.separator();
 
-    ui.add_enabled_ui(!connected, |ui| {
+    ui.add_enabled_ui(!connected && !connecting, |ui| {
         ui.horizontal(|ui| {
             ui.label(text(&language, "地址:", "Address:"));
             ui.text_edit_singleline(&mut state.rcon_ui.address);
@@ -50,7 +57,7 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     ui.horizontal(|ui| {
         if ui
             .add_enabled(
-                !connected,
+                !connected && !connecting,
                 egui::Button::new(text(&language, "连接", "Connect")),
             )
             .clicked()
@@ -59,12 +66,15 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
         }
         if ui
             .add_enabled(
-                connected,
+                connected || connecting,
                 egui::Button::new(text(&language, "断开", "Disconnect")),
             )
             .clicked()
         {
             disconnect_clicked = true;
+        }
+        if connecting {
+            ui.spinner();
         }
     });
 
@@ -72,15 +82,12 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     ui.label(text(&language, "原始命令", "Raw command"));
     ui.horizontal(|ui| {
         ui.add_enabled(
-            connected,
+            can_send,
             egui::TextEdit::singleline(&mut state.rcon_ui.command_input)
                 .desired_width(f32::INFINITY),
         );
         if ui
-            .add_enabled(
-                connected,
-                egui::Button::new(text(&language, "发送", "Send")),
-            )
+            .add_enabled(can_send, egui::Button::new(text(&language, "发送", "Send")))
             .clicked()
         {
             send_raw_clicked = true;
@@ -89,7 +96,7 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
 
     ui.horizontal(|ui| {
         for (label, command) in [
-            (text(&language, "Ping", "Ping"), "ping"),
+            ("Ping", "ping"),
             (text(&language, "状态", "Status"), "status"),
             (text(&language, "帮助", "Help"), "help"),
             (text(&language, "客户端", "Clients"), "clients"),
@@ -98,10 +105,7 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
                 "refresh_inventory",
             ),
         ] {
-            if ui
-                .add_enabled(connected, egui::Button::new(label))
-                .clicked()
-            {
+            if ui.add_enabled(can_send, egui::Button::new(label)).clicked() {
                 quick_command = Some(command);
             }
         }
@@ -109,35 +113,86 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
 
     ui.separator();
     ui.label(text(&language, "发送物品", "Give Item"));
-    ui.add_enabled_ui(connected, |ui| {
+    ui.add_enabled_ui(can_send, |ui| {
         ui.horizontal(|ui| {
-            ui.label(text(&language, "DefIndex:", "DefIndex:"));
-            ui.add(egui::DragValue::new(&mut state.rcon_ui.give_def_index).range(0..=u32::MAX));
+            ui.label(text(&language, "物品:", "Item:"));
+            ui.label(selected_item_label(state));
+            if ui.button(tr!("btn-select")).clicked() {
+                select_item_clicked = true;
+            }
             ui.label(text(&language, "数量:", "Count:"));
             ui.add(egui::DragValue::new(&mut state.rcon_ui.give_count).range(1..=100));
             ui.label(tr!("level"));
             ui.add(egui::DragValue::new(&mut state.rcon_ui.give_level).range(0..=100));
         });
+
         ui.horizontal(|ui| {
             ui.label(tr!("quality-id"));
-            ui.add(egui::DragValue::new(&mut state.rcon_ui.give_quality).range(0..=u32::MAX));
+            let selected_quality = state
+                .get_cached_quality_names()
+                .iter()
+                .find(|(value, _)| *value == state.rcon_ui.give_quality)
+                .map(|(_, name)| name.clone())
+                .unwrap_or_else(|| format!("Unknown ({})", state.rcon_ui.give_quality));
+            let qualities = state.get_cached_quality_names().to_vec();
+            egui::ComboBox::from_id_salt("rcon_quality_combo")
+                .selected_text(format!(
+                    "{} ({})",
+                    selected_quality, state.rcon_ui.give_quality
+                ))
+                .show_ui(ui, |ui| {
+                    for (value, name) in qualities {
+                        ui.selectable_value(
+                            &mut state.rcon_ui.give_quality,
+                            value,
+                            format!("{} ({})", name, value),
+                        );
+                    }
+                });
+
             ui.label(tr!("rarity"));
-            ui.add(egui::DragValue::new(&mut state.rcon_ui.give_rarity).range(0..=u32::MAX));
+            let selected_rarity = state
+                .get_cached_rarity_names()
+                .iter()
+                .find(|(value, _)| *value == state.rcon_ui.give_rarity)
+                .map(|(_, name)| name.clone())
+                .unwrap_or_else(|| format!("Unknown ({})", state.rcon_ui.give_rarity));
+            let rarities = state.get_cached_rarity_names().to_vec();
+            egui::ComboBox::from_id_salt("rcon_rarity_combo")
+                .selected_text(format!(
+                    "{} ({})",
+                    selected_rarity, state.rcon_ui.give_rarity
+                ))
+                .show_ui(ui, |ui| {
+                    for (value, name) in rarities {
+                        ui.selectable_value(
+                            &mut state.rcon_ui.give_rarity,
+                            value,
+                            format!("{} ({})", name, value),
+                        );
+                    }
+                });
         });
+
         ui.horizontal(|ui| {
             ui.label(tr!("custom-name"));
             ui.text_edit_singleline(&mut state.rcon_ui.give_custom_name);
         });
+
         ui.horizontal(|ui| {
             ui.label(text(&language, "涂装:", "Paint:"));
-            ui.text_edit_singleline(&mut state.rcon_ui.give_paint);
+            ui.label(selected_paint_label(state));
+            if ui.button(tr!("btn-select")).clicked() {
+                select_paint_clicked = true;
+            }
             ui.label(text(&language, "模板:", "Seed:"));
             ui.text_edit_singleline(&mut state.rcon_ui.give_seed);
             ui.label(text(&language, "磨损:", "Wear:"));
             ui.text_edit_singleline(&mut state.rcon_ui.give_wear);
-            ui.label(text(&language, "StatTrak:", "StatTrak:"));
+            ui.label("StatTrak:");
             ui.text_edit_singleline(&mut state.rcon_ui.give_stattrak);
         });
+
         if ui.button(text(&language, "发送物品", "Give")).clicked() {
             send_give_clicked = true;
         }
@@ -147,7 +202,7 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     ui.label(text(&language, "移除物品", "Remove Item"));
     ui.horizontal(|ui| {
         ui.add_enabled(
-            connected,
+            can_send,
             egui::TextEdit::singleline(&mut state.rcon_ui.remove_item_id).hint_text(text(
                 &language,
                 "物品 ID",
@@ -156,7 +211,7 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
         );
         if ui
             .add_enabled(
-                connected,
+                can_send,
                 egui::Button::new(text(&language, "移除", "Remove")),
             )
             .clicked()
@@ -184,6 +239,26 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     if disconnect_clicked {
         state.disconnect_rcon();
     }
+    if select_item_clicked {
+        let items = state.create_item_select_list();
+        state.open_select_window(
+            SelectWindowPurpose::RconItemDef,
+            text(&language, "选择物品", "Select Item").to_string(),
+            tr!("header-item-id").to_string(),
+            tr!("header-item-name").to_string(),
+            items,
+        );
+    }
+    if select_paint_clicked {
+        let items = state.create_skin_select_list_for_weapon(state.rcon_ui.give_def_index);
+        state.open_select_window(
+            SelectWindowPurpose::RconPaintKit,
+            text(&language, "选择涂装", "Select Paint Kit").to_string(),
+            tr!("header-paintkit-id").to_string(),
+            tr!("header-paintkit-name").to_string(),
+            items,
+        );
+    }
     if send_raw_clicked {
         let command = state.rcon_ui.command_input.clone();
         state.send_rcon_command(&command);
@@ -206,6 +281,25 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
             Err(_) => state.push_rcon_log("ERR invalid item id".to_string()),
         }
     }
+}
+
+fn selected_item_label(state: &CsgoInventoryEditor) -> String {
+    let name = state
+        .items_game
+        .get_item_display_name(state.rcon_ui.give_def_index, &state.translations);
+    format!("{} ({})", name, state.rcon_ui.give_def_index)
+}
+
+fn selected_paint_label(state: &CsgoInventoryEditor) -> String {
+    if state.rcon_ui.give_paint.trim().is_empty() {
+        return "-".to_string();
+    }
+    get_attribute_value_display_name(
+        crate::inventory::ItemAttribute::SkinPaintIndex.id(),
+        &state.rcon_ui.give_paint,
+        &state.items_game,
+        &state.translations,
+    )
 }
 
 fn build_manual_give_command(state: &CsgoInventoryEditor) -> Result<String, String> {

--- a/src/ui/rcon_page.rs
+++ b/src/ui/rcon_page.rs
@@ -1,0 +1,237 @@
+use crate::app::CsgoInventoryEditor;
+use eframe::egui;
+use egui_i18n::tr;
+
+pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
+    let connected = state.is_live_rcon();
+    let mut connect_clicked = false;
+    let mut disconnect_clicked = false;
+    let mut send_raw_clicked = false;
+    let mut quick_command: Option<&'static str> = None;
+    let mut send_give_clicked = false;
+    let mut remove_clicked = false;
+
+    ui.heading(tr!("rcon-title"));
+    ui.add_space(8.0);
+
+    ui.horizontal(|ui| {
+        let status = if connected {
+            tr!("rcon-status-connected")
+        } else {
+            tr!("rcon-status-disconnected")
+        };
+        ui.label(status);
+    });
+
+    ui.separator();
+
+    ui.add_enabled_ui(!connected, |ui| {
+        ui.horizontal(|ui| {
+            ui.label(tr!("rcon-address"));
+            ui.text_edit_singleline(&mut state.rcon_ui.address);
+            ui.label(tr!("rcon-port"));
+            ui.add(egui::DragValue::new(&mut state.rcon_ui.port).range(1..=65535));
+        });
+        ui.horizontal(|ui| {
+            ui.label(tr!("rcon-password"));
+            ui.add(egui::TextEdit::singleline(&mut state.rcon_ui.password).password(true));
+        });
+    });
+
+    ui.horizontal(|ui| {
+        if ui
+            .add_enabled(!connected, egui::Button::new(tr!("rcon-connect")))
+            .clicked()
+        {
+            connect_clicked = true;
+        }
+        if ui
+            .add_enabled(connected, egui::Button::new(tr!("rcon-disconnect")))
+            .clicked()
+        {
+            disconnect_clicked = true;
+        }
+    });
+
+    ui.separator();
+    ui.label(tr!("rcon-raw-command"));
+    ui.horizontal(|ui| {
+        ui.add_enabled(
+            connected,
+            egui::TextEdit::singleline(&mut state.rcon_ui.command_input)
+                .desired_width(f32::INFINITY),
+        );
+        if ui
+            .add_enabled(connected, egui::Button::new(tr!("rcon-send")))
+            .clicked()
+        {
+            send_raw_clicked = true;
+        }
+    });
+
+    ui.horizontal(|ui| {
+        for (label, command) in [
+            (tr!("rcon-ping"), "ping"),
+            (tr!("rcon-status"), "status"),
+            (tr!("rcon-help"), "help"),
+            (tr!("rcon-clients"), "clients"),
+            (tr!("rcon-refresh-inventory"), "refresh_inventory"),
+        ] {
+            if ui
+                .add_enabled(connected, egui::Button::new(label))
+                .clicked()
+            {
+                quick_command = Some(command);
+            }
+        }
+    });
+
+    ui.separator();
+    ui.label(tr!("rcon-give-item"));
+    ui.add_enabled_ui(connected, |ui| {
+        ui.horizontal(|ui| {
+            ui.label(tr!("rcon-defindex"));
+            ui.add(egui::DragValue::new(&mut state.rcon_ui.give_def_index).range(0..=u32::MAX));
+            ui.label(tr!("rcon-count"));
+            ui.add(egui::DragValue::new(&mut state.rcon_ui.give_count).range(1..=100));
+            ui.label(tr!("level"));
+            ui.add(egui::DragValue::new(&mut state.rcon_ui.give_level).range(0..=100));
+        });
+        ui.horizontal(|ui| {
+            ui.label(tr!("quality-id"));
+            ui.add(egui::DragValue::new(&mut state.rcon_ui.give_quality).range(0..=u32::MAX));
+            ui.label(tr!("rarity"));
+            ui.add(egui::DragValue::new(&mut state.rcon_ui.give_rarity).range(0..=u32::MAX));
+        });
+        ui.horizontal(|ui| {
+            ui.label(tr!("custom-name"));
+            ui.text_edit_singleline(&mut state.rcon_ui.give_custom_name);
+        });
+        ui.horizontal(|ui| {
+            ui.label(tr!("rcon-paint"));
+            ui.text_edit_singleline(&mut state.rcon_ui.give_paint);
+            ui.label(tr!("rcon-seed"));
+            ui.text_edit_singleline(&mut state.rcon_ui.give_seed);
+            ui.label(tr!("rcon-wear"));
+            ui.text_edit_singleline(&mut state.rcon_ui.give_wear);
+            ui.label(tr!("rcon-stattrak"));
+            ui.text_edit_singleline(&mut state.rcon_ui.give_stattrak);
+        });
+        if ui.button(tr!("rcon-give")).clicked() {
+            send_give_clicked = true;
+        }
+    });
+
+    ui.separator();
+    ui.label(tr!("rcon-remove-item"));
+    ui.horizontal(|ui| {
+        ui.add_enabled(
+            connected,
+            egui::TextEdit::singleline(&mut state.rcon_ui.remove_item_id)
+                .hint_text(tr!("rcon-item-id")),
+        );
+        if ui
+            .add_enabled(connected, egui::Button::new(tr!("rcon-remove")))
+            .clicked()
+        {
+            remove_clicked = true;
+        }
+    });
+
+    ui.separator();
+    ui.label(tr!("rcon-last-response"));
+    ui.monospace(&state.rcon_ui.last_response);
+    ui.add_space(8.0);
+    ui.label(tr!("rcon-log"));
+    egui::ScrollArea::vertical()
+        .stick_to_bottom(true)
+        .show(ui, |ui| {
+            for line in &state.rcon_ui.log {
+                ui.monospace(line);
+            }
+        });
+
+    if connect_clicked {
+        state.connect_rcon();
+    }
+    if disconnect_clicked {
+        state.disconnect_rcon();
+    }
+    if send_raw_clicked {
+        let command = state.rcon_ui.command_input.clone();
+        state.send_rcon_command(&command);
+    }
+    if let Some(command) = quick_command {
+        state.send_rcon_command(command);
+    }
+    if send_give_clicked {
+        match build_manual_give_command(state) {
+            Ok(command) => state.send_rcon_command(&command),
+            Err(e) => state.push_rcon_log(format!("ERR {}", e)),
+        }
+    }
+    if remove_clicked {
+        match state.rcon_ui.remove_item_id.trim().parse::<u64>() {
+            Ok(item_id) => {
+                let command = crate::rcon::commands::build_remove_item_command(item_id);
+                state.send_rcon_command(&command);
+            }
+            Err(_) => state.push_rcon_log("ERR invalid item id".to_string()),
+        }
+    }
+}
+
+fn build_manual_give_command(state: &CsgoInventoryEditor) -> Result<String, String> {
+    let count = state.rcon_ui.give_count;
+    if !(1..=100).contains(&count) {
+        return Err("count must be between 1 and 100".to_string());
+    }
+
+    let mut parts = vec![
+        "give_item".to_string(),
+        state.rcon_ui.give_def_index.to_string(),
+    ];
+    if count != 1 {
+        parts.push(count.to_string());
+    }
+    parts.push(format!("level={}", state.rcon_ui.give_level));
+    parts.push(format!("quality={}", state.rcon_ui.give_quality));
+    parts.push(format!("rarity={}", state.rcon_ui.give_rarity));
+
+    if !state.rcon_ui.give_custom_name.is_empty() {
+        parts.push(format!(
+            "name={}",
+            crate::rcon::commands::quote_value(&state.rcon_ui.give_custom_name)
+        ));
+    }
+    push_optional_u32(&mut parts, "paint", &state.rcon_ui.give_paint)?;
+    push_optional_u32(&mut parts, "seed", &state.rcon_ui.give_seed)?;
+    push_optional_f32(&mut parts, "wear", &state.rcon_ui.give_wear)?;
+    push_optional_u32(&mut parts, "stattrak", &state.rcon_ui.give_stattrak)?;
+
+    Ok(parts.join(" "))
+}
+
+fn push_optional_u32(parts: &mut Vec<String>, key: &str, value: &str) -> Result<(), String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+    let parsed = trimmed
+        .parse::<u32>()
+        .map_err(|_| format!("invalid parameter {}", key))?;
+    parts.push(format!("{}={}", key, parsed));
+    Ok(())
+}
+
+fn push_optional_f32(parts: &mut Vec<String>, key: &str, value: &str) -> Result<(), String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+    let parsed = trimmed
+        .parse::<f32>()
+        .map_err(|_| format!("invalid parameter {}", key))?;
+    parts.push(format!("{}={}", key, parsed));
+    Ok(())
+}

--- a/src/ui/rcon_page.rs
+++ b/src/ui/rcon_page.rs
@@ -3,6 +3,7 @@ use eframe::egui;
 use egui_i18n::tr;
 
 pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
+    let language = state.current_language.clone();
     let connected = state.is_live_rcon();
     let mut connect_clicked = false;
     let mut disconnect_clicked = false;
@@ -11,14 +12,22 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     let mut send_give_clicked = false;
     let mut remove_clicked = false;
 
-    ui.heading(tr!("rcon-title"));
+    ui.heading(text(&language, "RCON", "RCON"));
     ui.add_space(8.0);
 
     ui.horizontal(|ui| {
         let status = if connected {
-            tr!("rcon-status-connected")
+            text(
+                &language,
+                "已连接，离线文件为只读。",
+                "Connected. Offline files are read-only.",
+            )
         } else {
-            tr!("rcon-status-disconnected")
+            text(
+                &language,
+                "未连接，可以进行离线编辑。",
+                "Disconnected. Offline editing is available.",
+            )
         };
         ui.label(status);
     });
@@ -27,26 +36,32 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
 
     ui.add_enabled_ui(!connected, |ui| {
         ui.horizontal(|ui| {
-            ui.label(tr!("rcon-address"));
+            ui.label(text(&language, "地址:", "Address:"));
             ui.text_edit_singleline(&mut state.rcon_ui.address);
-            ui.label(tr!("rcon-port"));
+            ui.label(text(&language, "端口:", "Port:"));
             ui.add(egui::DragValue::new(&mut state.rcon_ui.port).range(1..=65535));
         });
         ui.horizontal(|ui| {
-            ui.label(tr!("rcon-password"));
+            ui.label(text(&language, "密码:", "Password:"));
             ui.add(egui::TextEdit::singleline(&mut state.rcon_ui.password).password(true));
         });
     });
 
     ui.horizontal(|ui| {
         if ui
-            .add_enabled(!connected, egui::Button::new(tr!("rcon-connect")))
+            .add_enabled(
+                !connected,
+                egui::Button::new(text(&language, "连接", "Connect")),
+            )
             .clicked()
         {
             connect_clicked = true;
         }
         if ui
-            .add_enabled(connected, egui::Button::new(tr!("rcon-disconnect")))
+            .add_enabled(
+                connected,
+                egui::Button::new(text(&language, "断开", "Disconnect")),
+            )
             .clicked()
         {
             disconnect_clicked = true;
@@ -54,7 +69,7 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     });
 
     ui.separator();
-    ui.label(tr!("rcon-raw-command"));
+    ui.label(text(&language, "原始命令", "Raw command"));
     ui.horizontal(|ui| {
         ui.add_enabled(
             connected,
@@ -62,7 +77,10 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
                 .desired_width(f32::INFINITY),
         );
         if ui
-            .add_enabled(connected, egui::Button::new(tr!("rcon-send")))
+            .add_enabled(
+                connected,
+                egui::Button::new(text(&language, "发送", "Send")),
+            )
             .clicked()
         {
             send_raw_clicked = true;
@@ -71,11 +89,14 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
 
     ui.horizontal(|ui| {
         for (label, command) in [
-            (tr!("rcon-ping"), "ping"),
-            (tr!("rcon-status"), "status"),
-            (tr!("rcon-help"), "help"),
-            (tr!("rcon-clients"), "clients"),
-            (tr!("rcon-refresh-inventory"), "refresh_inventory"),
+            (text(&language, "Ping", "Ping"), "ping"),
+            (text(&language, "状态", "Status"), "status"),
+            (text(&language, "帮助", "Help"), "help"),
+            (text(&language, "客户端", "Clients"), "clients"),
+            (
+                text(&language, "刷新库存", "Refresh Inventory"),
+                "refresh_inventory",
+            ),
         ] {
             if ui
                 .add_enabled(connected, egui::Button::new(label))
@@ -87,12 +108,12 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     });
 
     ui.separator();
-    ui.label(tr!("rcon-give-item"));
+    ui.label(text(&language, "发送物品", "Give Item"));
     ui.add_enabled_ui(connected, |ui| {
         ui.horizontal(|ui| {
-            ui.label(tr!("rcon-defindex"));
+            ui.label(text(&language, "DefIndex:", "DefIndex:"));
             ui.add(egui::DragValue::new(&mut state.rcon_ui.give_def_index).range(0..=u32::MAX));
-            ui.label(tr!("rcon-count"));
+            ui.label(text(&language, "数量:", "Count:"));
             ui.add(egui::DragValue::new(&mut state.rcon_ui.give_count).range(1..=100));
             ui.label(tr!("level"));
             ui.add(egui::DragValue::new(&mut state.rcon_ui.give_level).range(0..=100));
@@ -108,30 +129,36 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
             ui.text_edit_singleline(&mut state.rcon_ui.give_custom_name);
         });
         ui.horizontal(|ui| {
-            ui.label(tr!("rcon-paint"));
+            ui.label(text(&language, "涂装:", "Paint:"));
             ui.text_edit_singleline(&mut state.rcon_ui.give_paint);
-            ui.label(tr!("rcon-seed"));
+            ui.label(text(&language, "模板:", "Seed:"));
             ui.text_edit_singleline(&mut state.rcon_ui.give_seed);
-            ui.label(tr!("rcon-wear"));
+            ui.label(text(&language, "磨损:", "Wear:"));
             ui.text_edit_singleline(&mut state.rcon_ui.give_wear);
-            ui.label(tr!("rcon-stattrak"));
+            ui.label(text(&language, "StatTrak:", "StatTrak:"));
             ui.text_edit_singleline(&mut state.rcon_ui.give_stattrak);
         });
-        if ui.button(tr!("rcon-give")).clicked() {
+        if ui.button(text(&language, "发送物品", "Give")).clicked() {
             send_give_clicked = true;
         }
     });
 
     ui.separator();
-    ui.label(tr!("rcon-remove-item"));
+    ui.label(text(&language, "移除物品", "Remove Item"));
     ui.horizontal(|ui| {
         ui.add_enabled(
             connected,
-            egui::TextEdit::singleline(&mut state.rcon_ui.remove_item_id)
-                .hint_text(tr!("rcon-item-id")),
+            egui::TextEdit::singleline(&mut state.rcon_ui.remove_item_id).hint_text(text(
+                &language,
+                "物品 ID",
+                "Item ID",
+            )),
         );
         if ui
-            .add_enabled(connected, egui::Button::new(tr!("rcon-remove")))
+            .add_enabled(
+                connected,
+                egui::Button::new(text(&language, "移除", "Remove")),
+            )
             .clicked()
         {
             remove_clicked = true;
@@ -139,10 +166,10 @@ pub fn draw_rcon_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     });
 
     ui.separator();
-    ui.label(tr!("rcon-last-response"));
+    ui.label(text(&language, "最后响应", "Last Response"));
     ui.monospace(&state.rcon_ui.last_response);
     ui.add_space(8.0);
-    ui.label(tr!("rcon-log"));
+    ui.label(text(&language, "日志", "Log"));
     egui::ScrollArea::vertical()
         .stick_to_bottom(true)
         .show(ui, |ui| {
@@ -234,4 +261,8 @@ fn push_optional_f32(parts: &mut Vec<String>, key: &str, value: &str) -> Result<
         .map_err(|_| format!("invalid parameter {}", key))?;
     parts.push(format!("{}={}", key, parsed));
     Ok(())
+}
+
+fn text(language: &str, zh: &'static str, en: &'static str) -> &'static str {
+    if language == "zh-Hans" { zh } else { en }
 }

--- a/src/ui/rcon_page.rs
+++ b/src/ui/rcon_page.rs
@@ -567,6 +567,9 @@ fn push_optional_f32(parts: &mut Vec<String>, key: &str, value: &str) -> Result<
     let parsed = trimmed
         .parse::<f32>()
         .map_err(|_| format!("invalid parameter {}", key))?;
+    if !parsed.is_finite() {
+        return Err(format!("invalid parameter {}", key));
+    }
     parts.push(format!("{}={}", key, parsed));
     Ok(())
 }

--- a/src/ui/settings_page.rs
+++ b/src/ui/settings_page.rs
@@ -48,9 +48,20 @@ pub fn draw_settings_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
 }
 
 fn draw_config_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
+    let read_only = state.is_live_rcon();
     ui.vertical_centered(|ui| {
+        if read_only {
+            ui.label(
+                egui::RichText::new(tr!("readonly-rcon-message")).color(egui::Color32::YELLOW),
+            );
+            ui.add_space(8.0);
+        }
         egui::ScrollArea::vertical().show(ui, |ui| {
-            ui.vertical(|ui| {
+            ui.add_enabled_ui(!read_only, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label(tr!("appid-override"));
+                    ui.add(egui::DragValue::new(&mut state.config.appid_override));
+                });
                 ui.horizontal(|ui| {
                     ui.label(tr!("competitive-rank"));
                     ui.add(egui::DragValue::new(&mut state.config.competitive_rank));
@@ -122,12 +133,42 @@ fn draw_config_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
                         state.record_result(result, "save config");
                     }
                 });
+                ui.separator();
+                ui.label(tr!("config-rcon-title"));
+                ui.horizontal(|ui| {
+                    ui.label(tr!("config-rcon-enabled"));
+                    if ui.checkbox(&mut state.config.rcon_enabled, "").changed() {
+                        let _ = state.save_config();
+                    }
+                });
+                ui.horizontal(|ui| {
+                    ui.label(tr!("config-rcon-bind-address"));
+                    ui.text_edit_singleline(&mut state.config.rcon_bind_address);
+                });
+                ui.horizontal(|ui| {
+                    ui.label(tr!("config-rcon-port"));
+                    ui.add(egui::DragValue::new(&mut state.config.rcon_port).range(1..=65535));
+                });
+                ui.horizontal(|ui| {
+                    ui.label(tr!("config-rcon-password"));
+                    ui.add(egui::TextEdit::singleline(&mut state.config.rcon_password));
+                });
+                ui.horizontal(|ui| {
+                    ui.label(tr!("config-log-output"));
+                    ui.add(egui::DragValue::new(&mut state.config.log_output).range(0..=2));
+                });
+                ui.label(
+                    egui::RichText::new(tr!("config-rcon-restart-note")).color(egui::Color32::GRAY),
+                );
             });
         });
 
         ui.add_space(16.0);
 
-        if ui.button(tr!("save-config")).clicked() {
+        if ui
+            .add_enabled(!read_only, egui::Button::new(tr!("save-config")))
+            .clicked()
+        {
             let result = state.save_config();
             state.record_result(result, "save config");
         }

--- a/src/ui/settings_page.rs
+++ b/src/ui/settings_page.rs
@@ -157,7 +157,10 @@ fn draw_config_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
                 });
                 ui.horizontal(|ui| {
                     ui.label(text(&language, "密码:", "Password:"));
-                    ui.add(egui::TextEdit::singleline(&mut state.config.rcon_password));
+                    ui.add(
+                        egui::TextEdit::singleline(&mut state.config.rcon_password)
+                            .password(true),
+                    );
                 });
                 ui.horizontal(|ui| {
                     ui.label(text(&language, "日志输出:", "Log output:"));

--- a/src/ui/settings_page.rs
+++ b/src/ui/settings_page.rs
@@ -49,17 +49,23 @@ pub fn draw_settings_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
 
 fn draw_config_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     let read_only = state.is_live_rcon();
+    let language = state.current_language.clone();
     ui.vertical_centered(|ui| {
         if read_only {
+            let message = text(
+                &language,
+                "RCON 已连接。断开前 inventory.txt 和 config.txt 为只读。",
+                "RCON is connected. inventory.txt and config.txt are read-only until you disconnect.",
+            );
             ui.label(
-                egui::RichText::new(tr!("readonly-rcon-message")).color(egui::Color32::YELLOW),
+                egui::RichText::new(message).color(egui::Color32::YELLOW),
             );
             ui.add_space(8.0);
         }
         egui::ScrollArea::vertical().show(ui, |ui| {
             ui.add_enabled_ui(!read_only, |ui| {
                 ui.horizontal(|ui| {
-                    ui.label(tr!("appid-override"));
+                    ui.label(text(&language, "App ID 覆盖:", "App ID override:"));
                     ui.add(egui::DragValue::new(&mut state.config.appid_override));
                 });
                 ui.horizontal(|ui| {
@@ -134,32 +140,35 @@ fn draw_config_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
                     }
                 });
                 ui.separator();
-                ui.label(tr!("config-rcon-title"));
+                ui.label(text(&language, "目标 GC RCON", "Target GC RCON"));
                 ui.horizontal(|ui| {
-                    ui.label(tr!("config-rcon-enabled"));
+                    ui.label(text(&language, "启用 RCON 监听:", "Enable RCON listener:"));
                     if ui.checkbox(&mut state.config.rcon_enabled, "").changed() {
                         let _ = state.save_config();
                     }
                 });
                 ui.horizontal(|ui| {
-                    ui.label(tr!("config-rcon-bind-address"));
+                    ui.label(text(&language, "绑定地址:", "Bind address:"));
                     ui.text_edit_singleline(&mut state.config.rcon_bind_address);
                 });
                 ui.horizontal(|ui| {
-                    ui.label(tr!("config-rcon-port"));
+                    ui.label(text(&language, "端口:", "Port:"));
                     ui.add(egui::DragValue::new(&mut state.config.rcon_port).range(1..=65535));
                 });
                 ui.horizontal(|ui| {
-                    ui.label(tr!("config-rcon-password"));
+                    ui.label(text(&language, "密码:", "Password:"));
                     ui.add(egui::TextEdit::singleline(&mut state.config.rcon_password));
                 });
                 ui.horizontal(|ui| {
-                    ui.label(tr!("config-log-output"));
+                    ui.label(text(&language, "日志输出:", "Log output:"));
                     ui.add(egui::DragValue::new(&mut state.config.log_output).range(0..=2));
                 });
-                ui.label(
-                    egui::RichText::new(tr!("config-rcon-restart-note")).color(egui::Color32::GRAY),
-                );
+                ui.label(egui::RichText::new(text(
+                    &language,
+                    "csgo_gc 只在加载时读取此配置。修改 RCON 设置后需要重启或重新加载目标 GC。",
+                    "csgo_gc reads this configuration at load time. Restart or reload the target GC after changing RCON settings.",
+                ))
+                .color(egui::Color32::GRAY));
             });
         });
 
@@ -173,6 +182,10 @@ fn draw_config_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
             state.record_result(result, "save config");
         }
     });
+}
+
+fn text(language: &str, zh: &'static str, en: &'static str) -> &'static str {
+    if language == "zh-Hans" { zh } else { en }
 }
 
 fn draw_settings_content(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -11,6 +11,12 @@ pub fn draw_sidebar(ui: &mut egui::Ui, state: &mut crate::app::CsgoInventoryEdit
 
         ui.add_space(8.0);
 
+        if ui.button(tr!("sidebar-rcon")).clicked() {
+            state.current_page = crate::app::Page::Rcon;
+        }
+
+        ui.add_space(8.0);
+
         if ui.button(tr!("sidebar-settings")).clicked() {
             state.current_page = crate::app::Page::Settings;
         }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -11,7 +11,7 @@ pub fn draw_sidebar(ui: &mut egui::Ui, state: &mut crate::app::CsgoInventoryEdit
 
         ui.add_space(8.0);
 
-        if ui.button(tr!("sidebar-rcon")).clicked() {
+        if ui.button("RCON").clicked() {
             state.current_page = crate::app::Page::Rcon;
         }
 

--- a/src/ui/toolbar.rs
+++ b/src/ui/toolbar.rs
@@ -5,7 +5,13 @@ use crate::app::{CsgoInventoryEditor, ItemTemplate};
 
 pub fn draw_toolbar(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     ui.horizontal(|ui| {
-        if ui.button(tr!("btn-add-item")).clicked() {
+        if ui
+            .add_enabled(
+                !state.is_live_rcon(),
+                egui::Button::new(tr!("btn-add-item")),
+            )
+            .clicked()
+        {
             state.show_template_modal = true;
             state.selected_template = Some(ItemTemplate::Empty);
         }


### PR DESCRIPTION
Resolve #13 

## Summary
- Add an RCON client and command layer for live control of the game server
- Wire RCON connection state into app config, settings, and main application flow
- Add UI surfaces for RCON management alongside the inventory, detail, sidebar, and toolbar views
- Update localization and inventory handling to support the new workflow

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of Changes

* **New Features**
  * Added an RCON page to connect/disconnect, send raw commands (with quick actions), compose “give”/“remove” commands, and view the last response plus a collapsible RCON log.
  * Added RCON target settings (enabled, bind address/port, password) along with appid override and log output.
  * Added an “RCON” sidebar entry to navigate to the new page.

* **Bug Fixes**
  * When live RCON is connected, inventory/config editing and local saving are blocked with localized read-only warnings and disabled edit controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->