### PR TITLE
Clean up dead code and redundant logic

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use std::sync::mpsc::{self, Receiver};
 use std::time::Duration;
 
-// Type alias for select window items: (id, name, value, optional_color)
-pub type SelectWindowItem = (String, String, String, Option<String>);
+// Type alias for select window items: (id, name, optional_color)
+pub type SelectWindowItem = (String, String, Option<String>);
 pub type SelectWindowItems = Vec<SelectWindowItem>;
 
 // Type alias for online data fetch result: (data, timestamp, language)
@@ -931,7 +931,7 @@ impl CsgoInventoryEditor {
         self.data_provider
             .create_item_select_list()
             .into_iter()
-            .map(|(id, name, value)| (id, name, value, None))
+            .map(|(id, name, _value)| (id, name, None))
             .collect()
     }
 
@@ -939,7 +939,7 @@ impl CsgoInventoryEditor {
         self.data_provider
             .create_weapon_case_select_list()
             .into_iter()
-            .map(|(id, name, value)| (id, name, value, None))
+            .map(|(id, name, _value)| (id, name, None))
             .collect()
     }
 
@@ -981,16 +981,11 @@ impl CsgoInventoryEditor {
             .filter(|attr_id| !current_attributes.contains_key(attr_id))
             .map(|attr_id| {
                 let fluent_key = get_attribute_fluent_key(*attr_id);
-                (
-                    attr_id.to_string(),
-                    tr!(&fluent_key).to_string(),
-                    attr_id.to_string(),
-                    None,
-                )
+                (attr_id.to_string(), tr!(&fluent_key).to_string(), None)
             })
             .collect();
 
-        items.sort_by_key(|(id, _, _, _)| id.parse::<u32>().unwrap_or(0));
+        items.sort_by_key(|(id, _, _)| id.parse::<u32>().unwrap_or(0));
         items
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -553,7 +553,6 @@ impl CsgoInventoryEditor {
 
         // Try to load online data cache on startup
         if let Some((data, timestamp)) = load_cached_data(&settings.language) {
-            println!("[new] Online data cache found, loading...");
             app.data_provider = DataProvider::Online {
                 data: Arc::new(data.clone()),
                 items_game,
@@ -1014,12 +1013,10 @@ impl CsgoInventoryEditor {
             return;
         }
 
-        println!("[load_online_data] Starting fetch...");
         self.start_fetch_online_data();
     }
 
     pub fn start_fetch_online_data(&mut self) {
-        println!("[start_fetch_online_data] Starting...");
         let mirror_prefix = self.settings.mirror_site.get_prefix().to_string();
         let language = self.current_language.clone();
 
@@ -1027,27 +1024,20 @@ impl CsgoInventoryEditor {
         self.online_data_receiver = Some(rx);
 
         std::thread::spawn(move || {
-            println!("[BG Thread] Starting fetch...");
-            let result = fetch_online_data_with_progress(&language, &mirror_prefix, |msg: &str| {
-                println!("[BG Thread] Progress: {}", msg);
-            });
+            let result = fetch_online_data_with_progress(&language, &mirror_prefix, |_msg: &str| {});
 
             match result {
                 Ok(data) => {
-                    println!("[BG Thread] Fetch complete, saving cache...");
                     match save_cached_data(&language, &data) {
                         Ok(timestamp) => {
-                            println!("[BG Thread] Cache saved, sending result");
                             let _ = tx.send(Ok((data, timestamp, language)));
                         }
                         Err(e) => {
-                            println!("[BG Thread] Save error: {}", e);
                             let _ = tx.send(Err(e.to_string()));
                         }
                     }
                 }
                 Err(e) => {
-                    println!("[BG Thread] Fetch error: {}", e);
                     let _ = tx.send(Err(e.to_string()));
                 }
             }
@@ -1058,16 +1048,8 @@ impl CsgoInventoryEditor {
         if let Some(ref receiver) = self.online_data_receiver {
             match receiver.try_recv() {
                 Ok(Ok((data, timestamp, fetched_language))) => {
-                    println!(
-                        "[check_online_data_result] Received success result for language: {}",
-                        fetched_language
-                    );
                     // Discard result if language changed during fetch
                     if fetched_language != self.current_language {
-                        println!(
-                            "[check_online_data_result] Language mismatch (fetched: {}, current: {}), discarding result",
-                            fetched_language, self.current_language
-                        );
                         self.is_loading_online = false;
                         self.online_data_receiver = None;
                         return;
@@ -1083,14 +1065,12 @@ impl CsgoInventoryEditor {
                     self.online_data_receiver = None;
                     self.cached_item_display_names.borrow_mut().clear();
                 }
-                Ok(Err(e)) => {
-                    println!("[check_online_data_result] Received error: {}", e);
+                Ok(Err(_)) => {
                     self.is_loading_online = false;
                     self.online_data_receiver = None;
                 }
                 Err(mpsc::TryRecvError::Empty) => {}
                 Err(mpsc::TryRecvError::Disconnected) => {
-                    println!("[check_online_data_result] Channel disconnected");
                     self.is_loading_online = false;
                     self.online_data_receiver = None;
                 }
@@ -1106,7 +1086,6 @@ impl CsgoInventoryEditor {
         if self.is_fetching_online_data() {
             return;
         }
-        println!("[request_manual_update] Setting is_loading_online = true");
         self.is_loading_online = true;
         self.load_online_data();
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1024,19 +1024,18 @@ impl CsgoInventoryEditor {
         self.online_data_receiver = Some(rx);
 
         std::thread::spawn(move || {
-            let result = fetch_online_data_with_progress(&language, &mirror_prefix, |_msg: &str| {});
+            let result =
+                fetch_online_data_with_progress(&language, &mirror_prefix, |_msg: &str| {});
 
             match result {
-                Ok(data) => {
-                    match save_cached_data(&language, &data) {
-                        Ok(timestamp) => {
-                            let _ = tx.send(Ok((data, timestamp, language)));
-                        }
-                        Err(e) => {
-                            let _ = tx.send(Err(e.to_string()));
-                        }
+                Ok(data) => match save_cached_data(&language, &data) {
+                    Ok(timestamp) => {
+                        let _ = tx.send(Ok((data, timestamp, language)));
                     }
-                }
+                    Err(e) => {
+                        let _ = tx.send(Err(e.to_string()));
+                    }
+                },
                 Err(e) => {
                     let _ = tx.send(Err(e.to_string()));
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -931,7 +931,7 @@ impl CsgoInventoryEditor {
         self.data_provider
             .create_item_select_list()
             .into_iter()
-            .map(|(id, name, _value)| (id, name, None))
+            .map(|(id, name)| (id, name, None))
             .collect()
     }
 
@@ -939,7 +939,7 @@ impl CsgoInventoryEditor {
         self.data_provider
             .create_weapon_case_select_list()
             .into_iter()
-            .map(|(id, name, _value)| (id, name, None))
+            .map(|(id, name)| (id, name, None))
             .collect()
     }
 
@@ -1059,7 +1059,8 @@ impl CsgoInventoryEditor {
                     self.online_data_receiver = None;
                     self.cached_item_display_names.borrow_mut().clear();
                 }
-                Ok(Err(_)) => {
+                Ok(Err(e)) => {
+                    self.status_message = Some(e);
                     self.is_loading_online = false;
                     self.online_data_receiver = None;
                 }

--- a/src/core/game_dir.rs
+++ b/src/core/game_dir.rs
@@ -32,6 +32,14 @@ impl GameDir {
     }
 }
 
+pub(crate) fn editor_dir() -> PathBuf {
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+        .unwrap_or_else(|| PathBuf::from("."));
+    exe_dir.join("csgo_gc").join("editor")
+}
+
 #[derive(Debug)]
 pub enum GameDirError {
     NotFound { reason: String },

--- a/src/core/game_dir.rs
+++ b/src/core/game_dir.rs
@@ -5,7 +5,6 @@ pub const INVENTORY_FILE_NAME: &str = "csgo_gc/inventory.txt";
 #[derive(Debug)]
 pub struct GameDir {
     path: PathBuf,
-    inventory_path: PathBuf,
 }
 
 impl GameDir {
@@ -25,20 +24,11 @@ impl GameDir {
 
         Ok(Self {
             path: game_dir.to_path_buf(),
-            inventory_path,
         })
     }
 
     pub fn path(&self) -> &PathBuf {
         &self.path
-    }
-
-    pub fn inventory_path(&self) -> &PathBuf {
-        &self.inventory_path
-    }
-
-    pub fn inventory_exists(&self) -> bool {
-        self.inventory_path.exists()
     }
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,3 @@
 pub mod game_dir;
 
-pub use game_dir::{GameDir, GameDirError, INVENTORY_FILE_NAME};
+pub use game_dir::GameDir;

--- a/src/inventory/items_game.rs
+++ b/src/inventory/items_game.rs
@@ -247,33 +247,20 @@ impl ItemsGame {
         &self,
         translations: &GameTranslation,
     ) -> Vec<(String, String, String)> {
-        let mut items: Vec<(String, String, String)> = self
-            .items
-            .iter()
-            .map(|(def_index, ig_item)| {
-                let display_name = ig_item.get_display_name(translations);
-                (def_index.to_string(), display_name, def_index.to_string())
-            })
-            .collect();
-        items.sort_by_key(|(key, _, _)| key.parse::<u32>().unwrap_or(0));
-        items
+        build_select_list(&self.items, translations)
     }
 
     pub fn create_weapon_case_select_list(
         &self,
         translations: &GameTranslation,
     ) -> Vec<(String, String, String)> {
-        let mut items: Vec<(String, String, String)> = self
+        let cases: HashMap<u32, &IGItem> = self
             .items
             .iter()
             .filter(|(def_index, item)| **def_index != 0 && item.is_weapon_case())
-            .map(|(def_index, ig_item)| {
-                let display_name = ig_item.get_display_name(translations);
-                (def_index.to_string(), display_name, def_index.to_string())
-            })
+            .map(|(k, v)| (*k, v))
             .collect();
-        items.sort_by_key(|(key, _, _)| key.parse::<u32>().unwrap_or(0));
-        items
+        build_select_list(&cases, translations)
     }
 
     pub fn get_associated_item_def_indexes(&self, def_index: u32) -> &[u32] {
@@ -287,60 +274,21 @@ impl ItemsGame {
         &self,
         translations: &GameTranslation,
     ) -> Vec<(String, String, String)> {
-        let mut items: Vec<(String, String, String)> = self
-            .paint_kits
-            .iter()
-            .map(|(paint_index, paint_kit)| {
-                let display_name = paint_kit.get_display_name(translations);
-                (
-                    paint_index.to_string(),
-                    display_name,
-                    paint_index.to_string(),
-                )
-            })
-            .collect();
-        items.sort_by_key(|(key, _, _)| key.parse::<u32>().unwrap_or(0));
-        items
+        build_select_list(&self.paint_kits, translations)
     }
 
     pub fn create_music_def_select_list(
         &self,
         translations: &GameTranslation,
     ) -> Vec<(String, String, String)> {
-        let mut items: Vec<(String, String, String)> = self
-            .music_defs
-            .iter()
-            .map(|(music_index, music_def)| {
-                let display_name = music_def.get_display_name(translations);
-                (
-                    music_index.to_string(),
-                    display_name,
-                    music_index.to_string(),
-                )
-            })
-            .collect();
-        items.sort_by_key(|(key, _, _)| key.parse::<u32>().unwrap_or(0));
-        items
+        build_select_list(&self.music_defs, translations)
     }
 
     pub fn create_sticker_kit_select_list(
         &self,
         translations: &GameTranslation,
     ) -> Vec<(String, String, String)> {
-        let mut items: Vec<(String, String, String)> = self
-            .sticker_kits
-            .iter()
-            .map(|(sticker_index, sticker_kit)| {
-                let display_name = sticker_kit.get_display_name(translations);
-                (
-                    sticker_index.to_string(),
-                    display_name,
-                    sticker_index.to_string(),
-                )
-            })
-            .collect();
-        items.sort_by_key(|(key, _, _)| key.parse::<u32>().unwrap_or(0));
-        items
+        build_select_list(&self.sticker_kits, translations)
     }
 
     pub fn create_graffiti_tint_select_list(
@@ -361,4 +309,53 @@ impl ItemsGame {
         items.sort_by_key(|(key, _, _, _)| key.parse::<u32>().unwrap_or(0));
         items
     }
+}
+
+trait SelectDisplayName {
+    fn select_display_name(&self, translations: &GameTranslation) -> String;
+}
+
+impl SelectDisplayName for IGItem {
+    fn select_display_name(&self, translations: &GameTranslation) -> String {
+        self.get_display_name(translations)
+    }
+}
+
+impl SelectDisplayName for IGPaintKit {
+    fn select_display_name(&self, translations: &GameTranslation) -> String {
+        self.get_display_name(translations)
+    }
+}
+
+impl SelectDisplayName for IGStickerKit {
+    fn select_display_name(&self, translations: &GameTranslation) -> String {
+        self.get_display_name(translations)
+    }
+}
+
+impl SelectDisplayName for IGMusicDef {
+    fn select_display_name(&self, translations: &GameTranslation) -> String {
+        self.get_display_name(translations)
+    }
+}
+
+impl<T: SelectDisplayName + ?Sized> SelectDisplayName for &T {
+    fn select_display_name(&self, translations: &GameTranslation) -> String {
+        (**self).select_display_name(translations)
+    }
+}
+
+fn build_select_list<V: SelectDisplayName>(
+    map: &HashMap<u32, V>,
+    translations: &GameTranslation,
+) -> Vec<(String, String, String)> {
+    let mut items: Vec<(String, String, String)> = map
+        .iter()
+        .map(|(key, v)| {
+            let display_name = v.select_display_name(translations);
+            (key.to_string(), display_name, key.to_string())
+        })
+        .collect();
+    items.sort_by_key(|(key, _, _)| key.parse::<u32>().unwrap_or(0));
+    items
 }

--- a/src/inventory/items_game.rs
+++ b/src/inventory/items_game.rs
@@ -291,22 +291,19 @@ impl ItemsGame {
         build_select_list(&self.sticker_kits, translations)
     }
 
-    pub fn create_graffiti_tint_select_list(
-        &self,
-    ) -> Vec<(String, String, String, Option<String>)> {
-        let mut items: Vec<(String, String, String, Option<String>)> = self
+    pub fn create_graffiti_tint_select_list(&self) -> Vec<(String, String, Option<String>)> {
+        let mut items: Vec<(String, String, Option<String>)> = self
             .graffiti_tints
             .values()
             .map(|tint| {
                 (
                     tint.id.to_string(),
                     tint.name.clone(),
-                    tint.id.to_string(),
                     Some(tint.hex_color.clone()),
                 )
             })
             .collect();
-        items.sort_by_key(|(key, _, _, _)| key.parse::<u32>().unwrap_or(0));
+        items.sort_by_key(|(key, _, _)| key.parse::<u32>().unwrap_or(0));
         items
     }
 }

--- a/src/inventory/items_game.rs
+++ b/src/inventory/items_game.rs
@@ -251,13 +251,11 @@ impl ItemsGame {
         &self,
         translations: &GameTranslation,
     ) -> Vec<(String, String)> {
-        let cases: HashMap<u32, &IGItem> = self
+        let cases = self
             .items
             .iter()
-            .filter(|(def_index, item)| **def_index != 0 && item.is_weapon_case())
-            .map(|(k, v)| (*k, v))
-            .collect();
-        build_select_list(&cases, translations)
+            .filter(|(def_index, item)| **def_index != 0 && item.is_weapon_case());
+        build_select_list(cases, translations)
     }
 
     pub fn get_associated_item_def_indexes(&self, def_index: u32) -> &[u32] {
@@ -339,12 +337,13 @@ impl<T: SelectDisplayName + ?Sized> SelectDisplayName for &T {
     }
 }
 
-fn build_select_list<V: SelectDisplayName>(
-    map: &HashMap<u32, V>,
-    translations: &GameTranslation,
-) -> Vec<(String, String)> {
-    let mut items: Vec<(String, String)> = map
-        .iter()
+fn build_select_list<'a, V, I>(entries: I, translations: &GameTranslation) -> Vec<(String, String)>
+where
+    V: SelectDisplayName + 'a,
+    I: IntoIterator<Item = (&'a u32, V)>,
+{
+    let mut items: Vec<(String, String)> = entries
+        .into_iter()
         .map(|(key, v)| {
             let display_name = v.select_display_name(translations);
             (key.to_string(), display_name)

--- a/src/inventory/items_game.rs
+++ b/src/inventory/items_game.rs
@@ -12,8 +12,6 @@ pub struct IGItem {
     pub item_type_name: Option<String>,
     pub inv_container_and_tools: Option<String>,
     pub associated_items: Vec<u32>,
-    pub item_quality: Option<String>,
-    pub item_rarity: Option<String>,
 }
 
 impl IGItem {
@@ -88,19 +86,12 @@ pub struct IGRarity {
     pub value: u32,
     pub loc_key: String,
     pub loc_key_weapon: Option<String>,
-    pub loc_key_character: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IGQuality {
     pub name: String,
     pub value: u32,
-}
-
-impl IGQuality {
-    pub fn get_display_name(&self, translations: &GameTranslation) -> String {
-        translations.get(&self.name).unwrap_or(&self.name).clone()
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/inventory/items_game.rs
+++ b/src/inventory/items_game.rs
@@ -243,17 +243,14 @@ impl ItemsGame {
         item_name
     }
 
-    pub fn create_item_select_list(
-        &self,
-        translations: &GameTranslation,
-    ) -> Vec<(String, String, String)> {
+    pub fn create_item_select_list(&self, translations: &GameTranslation) -> Vec<(String, String)> {
         build_select_list(&self.items, translations)
     }
 
     pub fn create_weapon_case_select_list(
         &self,
         translations: &GameTranslation,
-    ) -> Vec<(String, String, String)> {
+    ) -> Vec<(String, String)> {
         let cases: HashMap<u32, &IGItem> = self
             .items
             .iter()
@@ -273,21 +270,21 @@ impl ItemsGame {
     pub fn create_paint_kit_select_list(
         &self,
         translations: &GameTranslation,
-    ) -> Vec<(String, String, String)> {
+    ) -> Vec<(String, String)> {
         build_select_list(&self.paint_kits, translations)
     }
 
     pub fn create_music_def_select_list(
         &self,
         translations: &GameTranslation,
-    ) -> Vec<(String, String, String)> {
+    ) -> Vec<(String, String)> {
         build_select_list(&self.music_defs, translations)
     }
 
     pub fn create_sticker_kit_select_list(
         &self,
         translations: &GameTranslation,
-    ) -> Vec<(String, String, String)> {
+    ) -> Vec<(String, String)> {
         build_select_list(&self.sticker_kits, translations)
     }
 
@@ -345,14 +342,14 @@ impl<T: SelectDisplayName + ?Sized> SelectDisplayName for &T {
 fn build_select_list<V: SelectDisplayName>(
     map: &HashMap<u32, V>,
     translations: &GameTranslation,
-) -> Vec<(String, String, String)> {
-    let mut items: Vec<(String, String, String)> = map
+) -> Vec<(String, String)> {
+    let mut items: Vec<(String, String)> = map
         .iter()
         .map(|(key, v)| {
             let display_name = v.select_display_name(translations);
-            (key.to_string(), display_name, key.to_string())
+            (key.to_string(), display_name)
         })
         .collect();
-    items.sort_by_key(|(key, _, _)| key.parse::<u32>().unwrap_or(0));
+    items.sort_by_key(|(key, _)| key.parse::<u32>().unwrap_or(0));
     items
 }

--- a/src/inventory/items_game_loader.rs
+++ b/src/inventory/items_game_loader.rs
@@ -41,7 +41,6 @@ impl ItemsGameLoader {
                         value: get_u32_from_obj(obj, "value").unwrap_or(0),
                         loc_key: get_string_from_obj(obj, "loc_key").unwrap_or_default(),
                         loc_key_weapon: get_string_from_obj(obj, "loc_key_weapon"),
-                        loc_key_character: get_string_from_obj(obj, "loc_key_character"),
                     };
                     items_game.rarities.insert(key.clone(), rarity);
                 }
@@ -102,18 +101,6 @@ impl ItemsGameLoader {
                             "inv_container_and_tools",
                         ),
                         associated_items: get_associated_items(obj, prefabs_obj, prefab.as_deref()),
-                        item_quality: get_inherited_string(
-                            obj,
-                            prefabs_obj,
-                            prefab.as_deref(),
-                            "item_quality",
-                        ),
-                        item_rarity: get_inherited_string(
-                            obj,
-                            prefabs_obj,
-                            prefab.as_deref(),
-                            "item_rarity",
-                        ),
                         prefab,
                     };
 

--- a/src/inventory/items_game_loader.rs
+++ b/src/inventory/items_game_loader.rs
@@ -1,7 +1,7 @@
 use crate::inventory::items_game::{
     IGGraffitiTint, IGItem, IGMusicDef, IGPaintKit, IGQuality, IGRarity, IGStickerKit, ItemsGame,
 };
-use crate::inventory::vdf::{VdfParser, VdfValue};
+use crate::inventory::vdf::{VdfParser, VdfValue, get_string_from_obj};
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -239,11 +239,6 @@ impl ItemsGameLoader {
             }
         }
     }
-}
-
-fn get_string_from_obj(obj: &HashMap<String, VdfValue>, key: &str) -> Option<String> {
-    obj.get(key)
-        .and_then(|v| v.as_string().map(|s| s.to_string()))
 }
 
 fn get_inherited_string(

--- a/src/inventory/language_file.rs
+++ b/src/inventory/language_file.rs
@@ -1,4 +1,5 @@
 use crate::inventory::items_game::GameTranslation;
+use crate::inventory::vdf::decode_escape;
 use std::path::Path;
 
 pub struct LanguageFileParser;
@@ -87,14 +88,7 @@ impl LanguageFileParser {
         let mut escaped = false;
         for ch in chars.by_ref() {
             if escaped {
-                key.push(match ch {
-                    'n' => '\n',
-                    'r' => '\r',
-                    't' => '\t',
-                    '"' => '"',
-                    '\\' => '\\',
-                    _ => ch,
-                });
+                key.push(decode_escape(ch).unwrap_or(ch));
                 escaped = false;
             } else if ch == '\\' {
                 escaped = true;
@@ -123,14 +117,7 @@ impl LanguageFileParser {
         escaped = false;
         for ch in chars.by_ref() {
             if escaped {
-                value.push(match ch {
-                    'n' => '\n',
-                    'r' => '\r',
-                    't' => '\t',
-                    '"' => '"',
-                    '\\' => '\\',
-                    _ => ch,
-                });
+                value.push(decode_escape(ch).unwrap_or(ch));
                 escaped = false;
             } else if ch == '\\' {
                 escaped = true;

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -19,5 +19,4 @@ pub use items_game_loader::{ItemsGameLoadError, ItemsGameLoader};
 pub use language_file::{LanguageFileLoadError, LanguageFileParser};
 pub use loader::{InventoryLoadError, InventoryLoader, InventorySaveError};
 pub use models::{DefaultEquip, Inventory, Item};
-pub use parser::{InventoryParser, VdfInventoryParser};
 pub use vdf::VdfParser;

--- a/src/inventory/parser.rs
+++ b/src/inventory/parser.rs
@@ -1,5 +1,5 @@
 use crate::inventory::models::{DefaultEquip, Inventory, Item};
-use crate::inventory::vdf::{VdfParser, VdfValue};
+use crate::inventory::vdf::{VdfParser, VdfValue, get_string_from_obj};
 use std::collections::HashMap;
 
 pub trait InventoryParser: Send + Sync {
@@ -130,7 +130,7 @@ fn parse_item(
         origin: get_u32(obj, "origin")?,
         in_use: get_u32(obj, "in_use")?,
         rarity: get_u32(obj, "rarity")?,
-        custom_name: get_string_opt(obj, "custom_name").map(|s| s.to_string()),
+        custom_name: get_string_from_obj(obj, "custom_name"),
         attributes: HashMap::new(),
         equipped_state: HashMap::new(),
     };
@@ -274,9 +274,4 @@ fn get_u32(
                 format!("Invalid value for '{}'", key),
             ))
         })
-}
-
-fn get_string_opt(obj: &HashMap<String, VdfValue>, key: &str) -> Option<String> {
-    obj.get(key)
-        .and_then(|v| v.as_string().map(|s| s.to_string()))
 }

--- a/src/inventory/vdf.rs
+++ b/src/inventory/vdf.rs
@@ -100,7 +100,7 @@ impl VdfParser {
 
                 let mut keys: Vec<_> = o.keys().collect();
 
-                let item_field_order = vec![
+                const ITEM_FIELD_ORDER: &[&str] = &[
                     "inventory",
                     "def_index",
                     "level",
@@ -114,7 +114,34 @@ impl VdfParser {
                     "equipped_state",
                 ];
 
-                let has_item_fields = o.keys().any(|k| item_field_order.contains(&k.as_str()));
+                const CONFIG_FIELD_ORDER: &[&str] = &[
+                    "appid_override",
+                    "ranks",
+                    "vac_banned",
+                    "cmd_friendly",
+                    "cmd_teaching",
+                    "cmd_leader",
+                    "player_level",
+                    "player_cur_xp",
+                    "rarity_weights",
+                    "destroy_used_items",
+                    "show_csgo_gc_servers_only",
+                    "rcon",
+                    "log_output",
+                ];
+
+                const RANKS_FIELD_ORDER: &[&str] = &[
+                    "competitive_rank",
+                    "competitive_wins",
+                    "wingman_rank",
+                    "wingman_wins",
+                    "dangerzone_rank",
+                    "dangerzone_wins",
+                ];
+
+                const RARITY_ORDER: &[&str] = &["1", "2", "3", "4", "5", "6", "99"];
+
+                let has_item_fields = o.keys().any(|k| ITEM_FIELD_ORDER.contains(&k.as_str()));
 
                 let is_attributes_or_equipped =
                     o.keys().all(|k| k.parse::<u64>().is_ok()) && !has_item_fields;
@@ -133,99 +160,19 @@ impl VdfParser {
 
                 let is_item_object = has_item_fields
                     && o.keys().all(|k| {
-                        item_field_order.contains(&k.as_str()) || k.parse::<u64>().is_ok()
+                        ITEM_FIELD_ORDER.contains(&k.as_str()) || k.parse::<u64>().is_ok()
                     });
 
                 if is_root_level {
-                    keys.sort_by(|a, b| {
-                        let a_priority = if a.as_str() == "items" {
-                            0
-                        } else if a.as_str() == "default_equips" {
-                            1
-                        } else {
-                            2
-                        };
-                        let b_priority = if b.as_str() == "items" {
-                            0
-                        } else if b.as_str() == "default_equips" {
-                            1
-                        } else {
-                            2
-                        };
-                        a_priority.cmp(&b_priority)
-                    });
+                    Self::sort_keys_by_order(&mut keys, &["items", "default_equips"]);
                 } else if is_config_root {
-                    let config_field_order = vec![
-                        "appid_override",
-                        "ranks",
-                        "vac_banned",
-                        "cmd_friendly",
-                        "cmd_teaching",
-                        "cmd_leader",
-                        "player_level",
-                        "player_cur_xp",
-                        "rarity_weights",
-                        "destroy_used_items",
-                        "show_csgo_gc_servers_only",
-                        "rcon",
-                        "log_output",
-                    ];
-                    keys.sort_by(|a, b| {
-                        let a_idx = config_field_order
-                            .iter()
-                            .position(|&x| x == a.as_str())
-                            .unwrap_or(usize::MAX);
-                        let b_idx = config_field_order
-                            .iter()
-                            .position(|&x| x == b.as_str())
-                            .unwrap_or(usize::MAX);
-                        a_idx.cmp(&b_idx)
-                    });
+                    Self::sort_keys_by_order(&mut keys, CONFIG_FIELD_ORDER);
                 } else if is_ranks_object {
-                    let ranks_field_order = [
-                        "competitive_rank",
-                        "competitive_wins",
-                        "wingman_rank",
-                        "wingman_wins",
-                        "dangerzone_rank",
-                        "dangerzone_wins",
-                    ];
-                    keys.sort_by(|a, b| {
-                        let a_idx = ranks_field_order
-                            .iter()
-                            .position(|&x| x == a.as_str())
-                            .unwrap_or(usize::MAX);
-                        let b_idx = ranks_field_order
-                            .iter()
-                            .position(|&x| x == b.as_str())
-                            .unwrap_or(usize::MAX);
-                        a_idx.cmp(&b_idx)
-                    });
+                    Self::sort_keys_by_order(&mut keys, RANKS_FIELD_ORDER);
                 } else if is_rarity_weights {
-                    let rarity_order = ["1", "2", "3", "4", "5", "6", "99"];
-                    keys.sort_by(|a, b| {
-                        let a_idx = rarity_order
-                            .iter()
-                            .position(|&x| x == a.as_str())
-                            .unwrap_or(usize::MAX);
-                        let b_idx = rarity_order
-                            .iter()
-                            .position(|&x| x == b.as_str())
-                            .unwrap_or(usize::MAX);
-                        a_idx.cmp(&b_idx)
-                    });
+                    Self::sort_keys_by_order(&mut keys, RARITY_ORDER);
                 } else if is_item_object {
-                    keys.sort_by(|a, b| {
-                        let a_idx = item_field_order
-                            .iter()
-                            .position(|&x| x == a.as_str())
-                            .unwrap_or(usize::MAX);
-                        let b_idx = item_field_order
-                            .iter()
-                            .position(|&x| x == b.as_str())
-                            .unwrap_or(usize::MAX);
-                        a_idx.cmp(&b_idx)
-                    });
+                    Self::sort_keys_by_order(&mut keys, ITEM_FIELD_ORDER);
                 } else if is_attributes_or_equipped {
                     keys.sort_by(|a, b| {
                         let a_num = a.parse::<u64>().unwrap_or(u64::MAX);
@@ -278,6 +225,36 @@ impl VdfParser {
             .replace('\r', "\\r")
             .replace('\t', "\\t")
     }
+
+    fn sort_keys_by_order(keys: &mut [&String], order: &[&str]) {
+        keys.sort_by(|a, b| {
+            let a_idx = order
+                .iter()
+                .position(|&x| x == a.as_str())
+                .unwrap_or(usize::MAX);
+            let b_idx = order
+                .iter()
+                .position(|&x| x == b.as_str())
+                .unwrap_or(usize::MAX);
+            a_idx.cmp(&b_idx)
+        });
+    }
+}
+
+pub(crate) fn decode_escape(ch: char) -> Option<char> {
+    match ch {
+        'n' => Some('\n'),
+        'r' => Some('\r'),
+        't' => Some('\t'),
+        '"' => Some('"'),
+        '\\' => Some('\\'),
+        _ => None,
+    }
+}
+
+pub(crate) fn get_string_from_obj(obj: &HashMap<String, VdfValue>, key: &str) -> Option<String> {
+    obj.get(key)
+        .and_then(|v| v.as_string().map(|s| s.to_string()))
 }
 
 #[derive(Debug, PartialEq)]
@@ -392,14 +369,7 @@ impl<'a> VdfTokenizer<'a> {
             let ch = self.content.as_bytes()[self.position];
 
             if escaped {
-                result.push(match ch {
-                    b'n' => '\n',
-                    b'r' => '\r',
-                    b't' => '\t',
-                    b'"' => '"',
-                    b'\\' => '\\',
-                    _ => ch as char,
-                });
+                result.push(decode_escape(ch as char).unwrap_or(ch as char));
                 escaped = false;
                 self.position += 1;
                 continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,8 +206,7 @@ impl eframe::App for CsgoInventoryEditor {
         if let Some(selected_idx) = self.select_window_selected {
             match self.select_window_purpose {
                 Some(SelectWindowPurpose::AddItem) => {
-                    if let Some((def_index_str, _, _, _)) =
-                        self.select_window_items.get(selected_idx)
+                    if let Some((def_index_str, _, _)) = self.select_window_items.get(selected_idx)
                         && let Ok(def_index) = def_index_str.parse::<u32>()
                     {
                         let new_inventory_id = self
@@ -237,8 +236,7 @@ impl eframe::App for CsgoInventoryEditor {
                 }
 
                 Some(SelectWindowPurpose::AddWeaponCase) => {
-                    if let Some((def_index_str, _, _, _)) =
-                        self.select_window_items.get(selected_idx)
+                    if let Some((def_index_str, _, _)) = self.select_window_items.get(selected_idx)
                         && let Ok(def_index) = def_index_str.parse::<u32>()
                     {
                         let mut next_inventory_id = self
@@ -284,7 +282,7 @@ impl eframe::App for CsgoInventoryEditor {
 
                 Some(SelectWindowPurpose::EditItemDef) => {
                     if let Some(for_item_id) = self.select_window_for_item
-                        && let Some((def_index_str, _, _, _)) =
+                        && let Some((def_index_str, _, _)) =
                             self.select_window_items.get(selected_idx)
                     {
                         if let Ok(def_index) = def_index_str.parse::<u32>() {
@@ -315,7 +313,7 @@ impl eframe::App for CsgoInventoryEditor {
 
                 Some(SelectWindowPurpose::SelectPaintKit) => {
                     if let Some(for_item_id) = self.select_window_for_item
-                        && let Some((paint_index_str, _, _, _)) =
+                        && let Some((paint_index_str, _, _)) =
                             self.select_window_items.get(selected_idx)
                     {
                         // Get def_index from the item being edited
@@ -345,14 +343,14 @@ impl eframe::App for CsgoInventoryEditor {
 
                 Some(SelectWindowPurpose::SelectMusicDef) => {
                     if let Some(for_item_id) = self.select_window_for_item
-                        && let Some((music_index_str, _, _, _)) =
+                        && let Some((music_index_str, _, _)) =
                             self.select_window_items.get(selected_idx)
                         && let Some(edit_state) = self.edit_item_states.get_mut(&for_item_id)
                     {
                         edit_state
                             .attributes
                             .insert(ItemAttribute::MusicID.id(), music_index_str.clone());
-                    } else if let Some((music_index_str, _, _, _)) =
+                    } else if let Some((music_index_str, _, _)) =
                         self.select_window_items.get(selected_idx)
                         && let Ok(music_id) = music_index_str.parse::<u32>()
                     {
@@ -387,7 +385,7 @@ impl eframe::App for CsgoInventoryEditor {
                 Some(SelectWindowPurpose::SelectStickerKit) => {
                     if let Some(for_item_id) = self.select_window_for_item
                         && let Some(for_attr_id) = self.select_window_for_attr
-                        && let Some((sticker_index_str, _, _, _)) =
+                        && let Some((sticker_index_str, _, _)) =
                             self.select_window_items.get(selected_idx)
                         && let Some(edit_state) = self.edit_item_states.get_mut(&for_item_id)
                     {
@@ -400,7 +398,7 @@ impl eframe::App for CsgoInventoryEditor {
 
                 Some(SelectWindowPurpose::SelectGraffitiTint) => {
                     if let Some(for_item_id) = self.select_window_for_item
-                        && let Some((tint_id_str, _, _, _)) =
+                        && let Some((tint_id_str, _, _)) =
                             self.select_window_items.get(selected_idx)
                         && let Some(edit_state) = self.edit_item_states.get_mut(&for_item_id)
                     {
@@ -413,7 +411,7 @@ impl eframe::App for CsgoInventoryEditor {
 
                 Some(SelectWindowPurpose::AddAttribute) => {
                     if let Some(for_item_id) = self.select_window_for_item
-                        && let Some((attr_id_str, _, _, _)) =
+                        && let Some((attr_id_str, _, _)) =
                             self.select_window_items.get(selected_idx)
                         && let Ok(attr_id) = attr_id_str.parse::<u32>()
                         && let Some(edit_state) = self.edit_item_states.get_mut(&for_item_id)
@@ -426,7 +424,7 @@ impl eframe::App for CsgoInventoryEditor {
                 }
 
                 Some(SelectWindowPurpose::RconItemDef) => {
-                    if let Some((value, _, _, _)) = self.select_window_items.get(selected_idx)
+                    if let Some((value, _, _)) = self.select_window_items.get(selected_idx)
                         && let Ok(def_index) = value.parse::<u32>()
                     {
                         self.rcon_ui.give_def_index = def_index;
@@ -437,7 +435,7 @@ impl eframe::App for CsgoInventoryEditor {
                 }
 
                 Some(SelectWindowPurpose::RconPaintKit) => {
-                    if let Some((value, _, _, _)) = self.select_window_items.get(selected_idx) {
+                    if let Some((value, _, _)) = self.select_window_items.get(selected_idx) {
                         self.rcon_ui.give_paint = value.clone();
                         if let Ok(paint_index) = value.parse::<u32>()
                             && let Some(rarity) =

--- a/src/online_data/api.rs
+++ b/src/online_data/api.rs
@@ -1,3 +1,4 @@
+use crate::core::game_dir::editor_dir;
 use crate::online_data::models::{InventoryData, OnlineGameData};
 use std::fs;
 use std::path::PathBuf;
@@ -7,11 +8,7 @@ const API_BASE: &str =
     "https://raw.githubusercontent.com/ByMykel/CSGO-API/refs/heads/main/public/api";
 
 fn get_cache_base_dir() -> PathBuf {
-    let exe_dir = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|p| p.to_path_buf()))
-        .unwrap_or_else(|| PathBuf::from("."));
-    exe_dir.join("csgo_gc").join("editor").join("cache")
+    editor_dir().join("cache")
 }
 
 fn get_cache_dir(language: &str) -> PathBuf {

--- a/src/online_data/api.rs
+++ b/src/online_data/api.rs
@@ -52,16 +52,11 @@ pub fn load_cached_data(language: &str) -> Option<(OnlineGameData, String)> {
     let meta_file = get_meta_file(language);
     let inventory_file = cache_dir.join("inventory.json");
 
-    println!("[load_cached_data] Cache directory: {:?}", cache_dir);
-    println!("[load_cached_data] Inventory file: {:?}", inventory_file);
-
     if !inventory_file.exists() {
-        println!("[load_cached_data] Missing inventory.json");
         return None;
     }
 
     if !meta_file.exists() {
-        println!("[load_cached_data] Missing meta.json");
         return None;
     }
 
@@ -74,7 +69,6 @@ pub fn load_cached_data(language: &str) -> Option<(OnlineGameData, String)> {
         inventory: Some(inventory),
     };
 
-    println!("[load_cached_data] Cache loaded successfully");
     Some((data, meta.timestamp))
 }
 
@@ -91,20 +85,14 @@ fn load_cache_file_single<T: serde::de::DeserializeOwned>(
 }
 
 pub fn save_cached_data(language: &str, data: &OnlineGameData) -> Result<String, ApiError> {
-    println!("[save_cached_data] Starting save...");
     let cache_dir = get_cache_dir(language);
     if !cache_dir.exists() {
-        println!(
-            "[save_cached_data] Creating cache directory: {:?}",
-            cache_dir
-        );
         fs::create_dir_all(&cache_dir).map_err(|e| ApiError::Cache(e.to_string()))?;
     }
 
     let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
 
     if let Some(ref inventory) = data.inventory {
-        println!("[save_cached_data] Saving inventory.json");
         save_cache_file_single(language, "inventory.json", inventory)?;
     }
 
@@ -116,10 +104,6 @@ pub fn save_cached_data(language: &str, data: &OnlineGameData) -> Result<String,
     let meta_file = get_meta_file(language);
     fs::write(&meta_file, meta_content).map_err(|e| ApiError::Cache(e.to_string()))?;
 
-    println!(
-        "[save_cached_data] All files saved successfully to {:?}",
-        cache_dir
-    );
     Ok(timestamp)
 }
 

--- a/src/online_data/mod.rs
+++ b/src/online_data/mod.rs
@@ -2,6 +2,6 @@ mod api;
 mod models;
 mod provider;
 
-pub use api::{ApiError, fetch_online_data_with_progress, load_cached_data, save_cached_data};
-pub use models::{InventoryData, OnlineGameData};
+pub use api::{fetch_online_data_with_progress, load_cached_data, save_cached_data};
+pub use models::OnlineGameData;
 pub use provider::DataProvider;

--- a/src/online_data/models.rs
+++ b/src/online_data/models.rs
@@ -84,18 +84,4 @@ impl OnlineGameData {
             .stickers
             .get(&sticker_index.to_string())
     }
-
-    pub fn get_inventory_graffiti(&self, graffiti_index: u32) -> Option<&InventorySkinItem> {
-        self.inventory
-            .as_ref()?
-            .graffiti
-            .get(&graffiti_index.to_string())
-    }
-
-    pub fn get_inventory_keychain(&self, keychain_index: u32) -> Option<&InventorySkinItem> {
-        self.inventory
-            .as_ref()?
-            .keychains
-            .get(&keychain_index.to_string())
-    }
 }

--- a/src/online_data/provider.rs
+++ b/src/online_data/provider.rs
@@ -194,7 +194,7 @@ impl DataProvider {
     }
 
     pub fn create_item_select_list(&self) -> Vec<(String, String)> {
-        let (items_game, translations) = match self {
+        match self {
             DataProvider::Local {
                 items_game,
                 translations,
@@ -203,13 +203,12 @@ impl DataProvider {
                 items_game,
                 translations,
                 ..
-            } => (items_game, translations),
-        };
-        items_game.create_item_select_list(translations)
+            } => items_game.create_item_select_list(translations),
+        }
     }
 
     pub fn create_weapon_case_select_list(&self) -> Vec<(String, String)> {
-        let (items_game, translations) = match self {
+        match self {
             DataProvider::Local {
                 items_game,
                 translations,
@@ -218,9 +217,8 @@ impl DataProvider {
                 items_game,
                 translations,
                 ..
-            } => (items_game, translations),
-        };
-        items_game.create_weapon_case_select_list(translations)
+            } => items_game.create_weapon_case_select_list(translations),
+        }
     }
 
     // Create skin select list for a specific weapon (online mode only shows skins for that weapon)

--- a/src/online_data/provider.rs
+++ b/src/online_data/provider.rs
@@ -1,6 +1,6 @@
 use crate::inventory::item_attribute::ItemAttribute;
 use crate::inventory::{GameTranslation, Item, ItemsGame};
-use crate::online_data::models::OnlineGameData;
+use crate::online_data::models::{InventorySkinItem, OnlineGameData};
 use std::sync::Arc;
 
 pub enum DataProvider {
@@ -17,20 +17,18 @@ pub enum DataProvider {
 
 impl DataProvider {
     pub fn get_item_display_name(&self, def_index: u32) -> String {
-        match self {
+        let (items_game, translations) = match self {
             DataProvider::Local {
                 items_game,
                 translations,
-            } => items_game.get_item_display_name(def_index, translations),
-            DataProvider::Online {
-                data: _data,
+            }
+            | DataProvider::Online {
                 items_game,
                 translations,
-            } => {
-                // Force use local data for display name (online format incompatible)
-                items_game.get_item_display_name(def_index, translations)
-            }
-        }
+                ..
+            } => (items_game, translations),
+        };
+        items_game.get_item_display_name(def_index, translations)
     }
 
     // Get skin display name from online inventory data (requires weapon_id and paint_index)
@@ -196,34 +194,33 @@ impl DataProvider {
     }
 
     pub fn create_item_select_list(&self) -> Vec<(String, String, String)> {
-        match self {
+        let (items_game, translations) = match self {
             DataProvider::Local {
                 items_game,
                 translations,
-            } => items_game.create_item_select_list(translations),
-            DataProvider::Online {
-                data: _data,
+            }
+            | DataProvider::Online {
                 items_game,
                 translations,
-            } => {
-                // Force use local data for display name (online format incompatible)
-                items_game.create_item_select_list(translations)
-            }
-        }
+                ..
+            } => (items_game, translations),
+        };
+        items_game.create_item_select_list(translations)
     }
 
     pub fn create_weapon_case_select_list(&self) -> Vec<(String, String, String)> {
-        match self {
+        let (items_game, translations) = match self {
             DataProvider::Local {
                 items_game,
                 translations,
-            } => items_game.create_weapon_case_select_list(translations),
-            DataProvider::Online {
-                data: _data,
+            }
+            | DataProvider::Online {
                 items_game,
                 translations,
-            } => items_game.create_weapon_case_select_list(translations),
-        }
+                ..
+            } => (items_game, translations),
+        };
+        items_game.create_weapon_case_select_list(translations)
     }
 
     // Create skin select list for a specific weapon (online mode only shows skins for that weapon)
@@ -293,21 +290,7 @@ impl DataProvider {
             } => {
                 // Use online inventory data for music kits with color
                 if let Some(ref inventory) = data.inventory {
-                    let mut items: Vec<(String, String, String, Option<String>)> = inventory
-                        .music_kits
-                        .iter()
-                        .map(|(music_index, music_kit)| {
-                            let color = music_kit.rarity.as_ref().map(|r| r.color.clone());
-                            (
-                                music_index.clone(),
-                                music_kit.name.clone(),
-                                music_index.clone(),
-                                color,
-                            )
-                        })
-                        .collect();
-                    items.sort_by_key(|(key, _, _, _)| key.parse::<u32>().unwrap_or(0));
-                    return items;
+                    return build_online_select_list(inventory.music_kits.iter());
                 }
                 // Fallback to local data
                 items_game
@@ -336,21 +319,7 @@ impl DataProvider {
             } => {
                 // Use online inventory data for stickers with color
                 if let Some(ref inventory) = data.inventory {
-                    let mut items: Vec<(String, String, String, Option<String>)> = inventory
-                        .stickers
-                        .iter()
-                        .map(|(sticker_index, sticker)| {
-                            let color = sticker.rarity.as_ref().map(|r| r.color.clone());
-                            (
-                                sticker_index.clone(),
-                                sticker.name.clone(),
-                                sticker_index.clone(),
-                                color,
-                            )
-                        })
-                        .collect();
-                    items.sort_by_key(|(key, _, _, _)| key.parse::<u32>().unwrap_or(0));
-                    return items;
+                    return build_online_select_list(inventory.stickers.iter());
                 }
                 // Fallback to local data
                 items_game
@@ -361,4 +330,17 @@ impl DataProvider {
             }
         }
     }
+}
+
+fn build_online_select_list<'a>(
+    entries: impl Iterator<Item = (&'a String, &'a InventorySkinItem)>,
+) -> Vec<(String, String, String, Option<String>)> {
+    let mut items: Vec<(String, String, String, Option<String>)> = entries
+        .map(|(index, item)| {
+            let color = item.rarity.as_ref().map(|r| r.color.clone());
+            (index.clone(), item.name.clone(), index.clone(), color)
+        })
+        .collect();
+    items.sort_by_key(|(key, _, _, _)| key.parse::<u32>().unwrap_or(0));
+    items
 }

--- a/src/online_data/provider.rs
+++ b/src/online_data/provider.rs
@@ -224,11 +224,11 @@ impl DataProvider {
     }
 
     // Create skin select list for a specific weapon (online mode only shows skins for that weapon)
-    // Returns (id, name, value, color) where color is optional hex color string
+    // Returns (id, name, color) where color is optional hex color string
     pub fn create_skin_select_list_for_weapon(
         &self,
         weapon_id: u32,
-    ) -> Vec<(String, String, String, Option<String>)> {
+    ) -> Vec<(String, String, Option<String>)> {
         match self {
             DataProvider::Local {
                 items_game,
@@ -236,7 +236,7 @@ impl DataProvider {
             } => items_game
                 .create_paint_kit_select_list(translations)
                 .into_iter()
-                .map(|(id, name, value)| (id, name, value, None))
+                .map(|(id, name, _value)| (id, name, None))
                 .collect(),
             DataProvider::Online {
                 data,
@@ -247,7 +247,7 @@ impl DataProvider {
                 if let Some(ref inventory) = data.inventory
                     && let Some(skins) = inventory.skins.get(&weapon_id.to_string())
                 {
-                    let mut items: Vec<(String, String, String, Option<String>)> = skins
+                    let mut items: Vec<(String, String, Option<String>)> = skins
                         .iter()
                         .map(|(paint_index, skin)| {
                             // "null" in online data means no paint (paint_index = 0)
@@ -257,23 +257,23 @@ impl DataProvider {
                                 paint_index.clone()
                             };
                             let color = skin.rarity.as_ref().map(|r| r.color.clone());
-                            (index.clone(), skin.name.clone(), index, color)
+                            (index.clone(), skin.name.clone(), color)
                         })
                         .collect();
-                    items.sort_by_key(|(key, _, _, _)| key.parse::<u32>().unwrap_or(0));
+                    items.sort_by_key(|(key, _, _)| key.parse::<u32>().unwrap_or(0));
                     return items;
                 }
                 // Fallback to local data
                 items_game
                     .create_paint_kit_select_list(translations)
                     .into_iter()
-                    .map(|(id, name, value)| (id, name, value, None))
+                    .map(|(id, name, _value)| (id, name, None))
                     .collect()
             }
         }
     }
 
-    pub fn create_music_def_select_list(&self) -> Vec<(String, String, String, Option<String>)> {
+    pub fn create_music_def_select_list(&self) -> Vec<(String, String, Option<String>)> {
         match self {
             DataProvider::Local {
                 items_game,
@@ -281,7 +281,7 @@ impl DataProvider {
             } => items_game
                 .create_music_def_select_list(translations)
                 .into_iter()
-                .map(|(id, name, value)| (id, name, value, None))
+                .map(|(id, name, _value)| (id, name, None))
                 .collect(),
             DataProvider::Online {
                 data,
@@ -296,13 +296,13 @@ impl DataProvider {
                 items_game
                     .create_music_def_select_list(translations)
                     .into_iter()
-                    .map(|(id, name, value)| (id, name, value, None))
+                    .map(|(id, name, _value)| (id, name, None))
                     .collect()
             }
         }
     }
 
-    pub fn create_sticker_kit_select_list(&self) -> Vec<(String, String, String, Option<String>)> {
+    pub fn create_sticker_kit_select_list(&self) -> Vec<(String, String, Option<String>)> {
         match self {
             DataProvider::Local {
                 items_game,
@@ -310,7 +310,7 @@ impl DataProvider {
             } => items_game
                 .create_sticker_kit_select_list(translations)
                 .into_iter()
-                .map(|(id, name, value)| (id, name, value, None))
+                .map(|(id, name, _value)| (id, name, None))
                 .collect(),
             DataProvider::Online {
                 data,
@@ -325,7 +325,7 @@ impl DataProvider {
                 items_game
                     .create_sticker_kit_select_list(translations)
                     .into_iter()
-                    .map(|(id, name, value)| (id, name, value, None))
+                    .map(|(id, name, _value)| (id, name, None))
                     .collect()
             }
         }
@@ -334,13 +334,13 @@ impl DataProvider {
 
 fn build_online_select_list<'a>(
     entries: impl Iterator<Item = (&'a String, &'a InventorySkinItem)>,
-) -> Vec<(String, String, String, Option<String>)> {
-    let mut items: Vec<(String, String, String, Option<String>)> = entries
+) -> Vec<(String, String, Option<String>)> {
+    let mut items: Vec<(String, String, Option<String>)> = entries
         .map(|(index, item)| {
             let color = item.rarity.as_ref().map(|r| r.color.clone());
-            (index.clone(), item.name.clone(), index.clone(), color)
+            (index.clone(), item.name.clone(), color)
         })
         .collect();
-    items.sort_by_key(|(key, _, _, _)| key.parse::<u32>().unwrap_or(0));
+    items.sort_by_key(|(key, _, _)| key.parse::<u32>().unwrap_or(0));
     items
 }

--- a/src/online_data/provider.rs
+++ b/src/online_data/provider.rs
@@ -95,20 +95,6 @@ impl DataProvider {
         }
     }
 
-    pub fn get_paint_kit_rarity(&self, paint_index: u32) -> Option<u32> {
-        match self {
-            DataProvider::Local {
-                items_game,
-                translations: _translations,
-            } => items_game.get_paint_kit_rarity(paint_index),
-            DataProvider::Online {
-                data: _data,
-                items_game,
-                translations: _translations,
-            } => items_game.get_paint_kit_rarity(paint_index),
-        }
-    }
-
     // Get skin rarity from online inventory data (requires weapon_id and paint_index)
     pub fn get_skin_rarity(&self, weapon_id: u32, paint_index: u32) -> Option<u32> {
         match self {

--- a/src/online_data/provider.rs
+++ b/src/online_data/provider.rs
@@ -193,7 +193,7 @@ impl DataProvider {
         item_name
     }
 
-    pub fn create_item_select_list(&self) -> Vec<(String, String, String)> {
+    pub fn create_item_select_list(&self) -> Vec<(String, String)> {
         let (items_game, translations) = match self {
             DataProvider::Local {
                 items_game,
@@ -208,7 +208,7 @@ impl DataProvider {
         items_game.create_item_select_list(translations)
     }
 
-    pub fn create_weapon_case_select_list(&self) -> Vec<(String, String, String)> {
+    pub fn create_weapon_case_select_list(&self) -> Vec<(String, String)> {
         let (items_game, translations) = match self {
             DataProvider::Local {
                 items_game,
@@ -236,7 +236,7 @@ impl DataProvider {
             } => items_game
                 .create_paint_kit_select_list(translations)
                 .into_iter()
-                .map(|(id, name, _value)| (id, name, None))
+                .map(|(id, name)| (id, name, None))
                 .collect(),
             DataProvider::Online {
                 data,
@@ -257,7 +257,7 @@ impl DataProvider {
                                 paint_index.clone()
                             };
                             let color = skin.rarity.as_ref().map(|r| r.color.clone());
-                            (index.clone(), skin.name.clone(), color)
+                            (index, skin.name.clone(), color)
                         })
                         .collect();
                     items.sort_by_key(|(key, _, _)| key.parse::<u32>().unwrap_or(0));
@@ -267,7 +267,7 @@ impl DataProvider {
                 items_game
                     .create_paint_kit_select_list(translations)
                     .into_iter()
-                    .map(|(id, name, _value)| (id, name, None))
+                    .map(|(id, name)| (id, name, None))
                     .collect()
             }
         }
@@ -281,7 +281,7 @@ impl DataProvider {
             } => items_game
                 .create_music_def_select_list(translations)
                 .into_iter()
-                .map(|(id, name, _value)| (id, name, None))
+                .map(|(id, name)| (id, name, None))
                 .collect(),
             DataProvider::Online {
                 data,
@@ -296,7 +296,7 @@ impl DataProvider {
                 items_game
                     .create_music_def_select_list(translations)
                     .into_iter()
-                    .map(|(id, name, _value)| (id, name, None))
+                    .map(|(id, name)| (id, name, None))
                     .collect()
             }
         }
@@ -310,7 +310,7 @@ impl DataProvider {
             } => items_game
                 .create_sticker_kit_select_list(translations)
                 .into_iter()
-                .map(|(id, name, _value)| (id, name, None))
+                .map(|(id, name)| (id, name, None))
                 .collect(),
             DataProvider::Online {
                 data,
@@ -325,7 +325,7 @@ impl DataProvider {
                 items_game
                     .create_sticker_kit_select_list(translations)
                     .into_iter()
-                    .map(|(id, name, _value)| (id, name, None))
+                    .map(|(id, name)| (id, name, None))
                     .collect()
             }
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,13 +1,10 @@
+use crate::core::game_dir::editor_dir;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
 fn get_settings_file() -> PathBuf {
-    let exe_dir = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|p| p.to_path_buf()))
-        .unwrap_or_else(|| PathBuf::from("."));
-    exe_dir.join("csgo_gc").join("editor").join("settings.json")
+    editor_dir().join("settings.json")
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -137,8 +137,4 @@ impl Settings {
     pub fn set_language(&mut self, language: String) {
         self.language = language;
     }
-
-    pub fn set_theme(&mut self, theme: Theme) {
-        self.theme = theme;
-    }
 }

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -56,3 +56,28 @@ pub(crate) fn draw_status_message(ui: &mut egui::Ui, message: &str) {
         status_label,
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_chinese_only_matches_zh_hans() {
+        assert!(is_chinese("zh-Hans"));
+        assert!(!is_chinese("en"));
+        assert!(!is_chinese("zh-Hant"));
+        assert!(!is_chinese(""));
+    }
+
+    #[test]
+    fn rcon_readonly_message_is_language_specific() {
+        assert_eq!(
+            rcon_readonly_message("zh-Hans"),
+            "RCON 已连接。断开前 inventory.txt 和 config.txt 为只读。"
+        );
+        assert_eq!(
+            rcon_readonly_message("en"),
+            "RCON is connected. inventory.txt and config.txt are read-only until you disconnect."
+        );
+    }
+}

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -1,0 +1,58 @@
+use eframe::egui;
+
+pub(crate) fn is_chinese(language: &str) -> bool {
+    language == "zh-Hans"
+}
+
+pub(crate) fn rcon_readonly_message(language: &str) -> &'static str {
+    if is_chinese(language) {
+        "RCON 已连接。断开前 inventory.txt 和 config.txt 为只读。"
+    } else {
+        "RCON is connected. inventory.txt and config.txt are read-only until you disconnect."
+    }
+}
+
+pub(crate) fn draw_named_combo(
+    ui: &mut egui::Ui,
+    id_salt: impl Into<String>,
+    cache: &[(u32, String)],
+    selected: &mut u32,
+    read_only: bool,
+    width: Option<f32>,
+) {
+    let selected_name = cache
+        .iter()
+        .find(|(v, _)| *v == *selected)
+        .map(|(_, name)| name.clone())
+        .unwrap_or_else(|| format!("Unknown ({})", *selected));
+
+    let mut combo = egui::ComboBox::from_id_salt(id_salt.into())
+        .selected_text(format!("{} ({})", selected_name, *selected));
+    if let Some(w) = width {
+        combo = combo.width(w);
+    }
+
+    ui.add_enabled_ui(!read_only, |ui| {
+        combo.show_ui(ui, |ui| {
+            for (value, name) in cache {
+                ui.selectable_value(selected, *value, format!("{} ({})", name, value));
+            }
+        });
+    });
+}
+
+pub(crate) fn draw_status_message(ui: &mut egui::Ui, message: &str) {
+    let status_label = egui::Label::new(
+        egui::RichText::new(message)
+            .color(egui::Color32::LIGHT_RED)
+            .size(13.0),
+    )
+    .truncate();
+    ui.add_sized(
+        egui::vec2(
+            ui.available_width(),
+            ui.text_style_height(&egui::TextStyle::Body),
+        ),
+        status_label,
+    );
+}

--- a/src/ui/inventory_page.rs
+++ b/src/ui/inventory_page.rs
@@ -32,14 +32,8 @@ pub fn draw_inventory_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     } else {
         egui::Panel::top("toolbar").show_inside(ui, |ui| {
             if state.is_live_rcon() {
-                let message = if state.current_language == "zh-Hans" {
-                    "RCON 已连接。断开前 inventory.txt 和 config.txt 为只读。"
-                } else {
-                    "RCON is connected. inventory.txt and config.txt are read-only until you disconnect."
-                };
-                ui.label(
-                    egui::RichText::new(message).color(egui::Color32::YELLOW),
-                );
+                let message = crate::ui::rcon_readonly_message(&state.current_language);
+                ui.label(egui::RichText::new(message).color(egui::Color32::YELLOW));
                 ui.separator();
             }
             crate::ui::draw_toolbar(ui, state);

--- a/src/ui/item_detail.rs
+++ b/src/ui/item_detail.rs
@@ -108,7 +108,7 @@ pub fn draw_item_detail_windows(
                     if ui
                         .add_enabled(
                             read_only,
-                            egui::Button::new(if state.current_language == "zh-Hans" {
+                            egui::Button::new(if crate::ui::is_chinese(&state.current_language) {
                                 "通过 RCON 发送"
                             } else {
                                 "Send via RCON"
@@ -185,28 +185,14 @@ pub fn draw_item_detail_windows(
                         });
                         row.col(|ui| {
                             let all_qualities = state.get_cached_quality_names();
-                            let selected_name = all_qualities
-                                .iter()
-                                .find(|(v, _)| *v == edit_state.quality)
-                                .map(|(_, name)| name.clone())
-                                .unwrap_or_else(|| format!("Unknown ({})", edit_state.quality));
-
-                            ui.add_enabled_ui(!read_only, |ui| {
-                                egui::ComboBox::from_id_salt(format!("quality_combo_{}", item_id))
-                                    .selected_text(format!(
-                                        "{} ({})",
-                                        selected_name, edit_state.quality
-                                    ))
-                                    .show_ui(ui, |ui| {
-                                        for (value, name) in all_qualities {
-                                            ui.selectable_value(
-                                                &mut edit_state.quality,
-                                                *value,
-                                                format!("{} ({})", name, value),
-                                            );
-                                        }
-                                    });
-                            });
+                            crate::ui::draw_named_combo(
+                                ui,
+                                format!("quality_combo_{}", item_id),
+                                all_qualities,
+                                &mut edit_state.quality,
+                                read_only,
+                                None,
+                            );
                         });
                     });
 
@@ -216,29 +202,14 @@ pub fn draw_item_detail_windows(
                         });
                         row.col(|ui| {
                             let rarity_names = state.get_cached_rarity_names();
-
-                            let selected_name = rarity_names
-                                .iter()
-                                .find(|(v, _)| *v == edit_state.rarity)
-                                .map(|(_, n)| n.clone())
-                                .unwrap_or_else(|| format!("Unknown ({})", edit_state.rarity));
-
-                            ui.add_enabled_ui(!read_only, |ui| {
-                                egui::ComboBox::from_id_salt(format!("rarity_combo_{}", item_id))
-                                    .selected_text(format!(
-                                        "{} ({})",
-                                        selected_name, edit_state.rarity
-                                    ))
-                                    .show_ui(ui, |ui| {
-                                        for (value, name) in rarity_names {
-                                            ui.selectable_value(
-                                                &mut edit_state.rarity,
-                                                *value,
-                                                format!("{} ({})", name, value),
-                                            );
-                                        }
-                                    });
-                            });
+                            crate::ui::draw_named_combo(
+                                ui,
+                                format!("rarity_combo_{}", item_id),
+                                rarity_names,
+                                &mut edit_state.rarity,
+                                read_only,
+                                None,
+                            );
                         });
                     });
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod helpers;
 pub mod inventory_page;
 pub mod item_detail;
 pub mod item_grid;
@@ -6,6 +7,10 @@ pub mod select_window;
 pub mod settings_page;
 pub mod sidebar;
 pub mod toolbar;
+
+pub(crate) use helpers::{
+    draw_named_combo, draw_status_message, is_chinese, rcon_readonly_message,
+};
 
 pub use inventory_page::draw_inventory_page;
 pub use item_detail::draw_item_detail_windows;

--- a/src/ui/rcon_page.rs
+++ b/src/ui/rcon_page.rs
@@ -79,7 +79,7 @@ enum RconLabel {
 }
 
 fn label(state: &CsgoInventoryEditor, label: RconLabel) -> &'static str {
-    let zh = state.current_language == "zh-Hans";
+    let zh = crate::ui::is_chinese(&state.current_language);
     match (zh, label) {
         (_, RconLabel::Title) => "RCON",
         (true, RconLabel::Connecting) => "\u{6b63}\u{5728}\u{8fde}\u{63a5}...",
@@ -349,53 +349,27 @@ fn draw_give_item(
 }
 
 fn draw_quality_combo(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
-    let selected_quality = state
-        .get_cached_quality_names()
-        .iter()
-        .find(|(value, _)| *value == state.rcon_ui.give_quality)
-        .map(|(_, name)| name.clone())
-        .unwrap_or_else(|| format!("Unknown ({})", state.rcon_ui.give_quality));
     let qualities = state.get_cached_quality_names().to_vec();
-    egui::ComboBox::from_id_salt("rcon_quality_combo")
-        .width(ui.available_width().min(320.0))
-        .selected_text(format!(
-            "{} ({})",
-            selected_quality, state.rcon_ui.give_quality
-        ))
-        .show_ui(ui, |ui| {
-            for (value, name) in qualities {
-                ui.selectable_value(
-                    &mut state.rcon_ui.give_quality,
-                    value,
-                    format!("{} ({})", name, value),
-                );
-            }
-        });
+    crate::ui::draw_named_combo(
+        ui,
+        "rcon_quality_combo",
+        &qualities,
+        &mut state.rcon_ui.give_quality,
+        false,
+        Some(ui.available_width().min(320.0)),
+    );
 }
 
 fn draw_rarity_combo(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
-    let selected_rarity = state
-        .get_cached_rarity_names()
-        .iter()
-        .find(|(value, _)| *value == state.rcon_ui.give_rarity)
-        .map(|(_, name)| name.clone())
-        .unwrap_or_else(|| format!("Unknown ({})", state.rcon_ui.give_rarity));
     let rarities = state.get_cached_rarity_names().to_vec();
-    egui::ComboBox::from_id_salt("rcon_rarity_combo")
-        .width(ui.available_width().min(320.0))
-        .selected_text(format!(
-            "{} ({})",
-            selected_rarity, state.rcon_ui.give_rarity
-        ))
-        .show_ui(ui, |ui| {
-            for (value, name) in rarities {
-                ui.selectable_value(
-                    &mut state.rcon_ui.give_rarity,
-                    value,
-                    format!("{} ({})", name, value),
-                );
-            }
-        });
+    crate::ui::draw_named_combo(
+        ui,
+        "rcon_rarity_combo",
+        &rarities,
+        &mut state.rcon_ui.give_rarity,
+        false,
+        Some(ui.available_width().min(320.0)),
+    );
 }
 
 fn labeled_text(ui: &mut egui::Ui, label: &str, value: &mut String) {

--- a/src/ui/select_window.rs
+++ b/src/ui/select_window.rs
@@ -46,15 +46,15 @@ pub fn draw_select_window(
                 .iter()
                 .map(|&idx| {
                     let item = &items[idx];
-                    (idx, &item.0, &item.1, &item.2, &item.3)
+                    (idx, &item.0, &item.1, &item.2)
                 })
                 .collect()
         } else {
             let search_lower = search.to_lowercase();
-            let filtered: Vec<(usize, &String, &String, &String, &Option<String>)> = items
+            let filtered: Vec<(usize, &String, &String, &Option<String>)> = items
                 .iter()
                 .enumerate()
-                .filter(|(_, (key, display, _, _))| {
+                .filter(|(_, (key, display, _))| {
                     if search.is_empty() {
                         true
                     } else {
@@ -62,10 +62,10 @@ pub fn draw_select_window(
                             || display.to_lowercase().contains(&search_lower)
                     }
                 })
-                .map(|(idx, item)| (idx, &item.0, &item.1, &item.2, &item.3))
+                .map(|(idx, item)| (idx, &item.0, &item.1, &item.2))
                 .collect();
 
-            let indices: Vec<usize> = filtered.iter().map(|(idx, _, _, _, _)| *idx).collect();
+            let indices: Vec<usize> = filtered.iter().map(|(idx, _, _, _)| *idx).collect();
             cache_data.0 = search.clone();
             cache_data.1 = items.len();
             cache_data.2 = indices;
@@ -122,13 +122,8 @@ pub fn draw_select_window(
                 })
                 .body(|body| {
                     body.rows(text_height, filtered_items.len(), |mut row| {
-                        let (idx, key, display, _, color): (
-                            usize,
-                            &String,
-                            &String,
-                            &String,
-                            &Option<String>,
-                        ) = filtered_items[row.index()];
+                        let (idx, key, display, color): (usize, &String, &String, &Option<String>) =
+                            filtered_items[row.index()];
                         let is_selected = *selected == Some(idx);
                         row.set_selected(is_selected);
 

--- a/src/ui/settings_page.rs
+++ b/src/ui/settings_page.rs
@@ -26,11 +26,7 @@ pub fn draw_settings_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     ui.separator();
 
     if let Some(message) = &state.status_message {
-        ui.label(
-            egui::RichText::new(message)
-                .color(egui::Color32::LIGHT_RED)
-                .size(13.0),
-        );
+        crate::ui::draw_status_message(ui, message);
         ui.separator();
     }
 
@@ -52,11 +48,7 @@ fn draw_config_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
     let language = state.current_language.clone();
     ui.vertical_centered(|ui| {
         if read_only {
-            let message = text(
-                &language,
-                "RCON 已连接。断开前 inventory.txt 和 config.txt 为只读。",
-                "RCON is connected. inventory.txt and config.txt are read-only until you disconnect.",
-            );
+            let message = crate::ui::rcon_readonly_message(&language);
             ui.label(
                 egui::RichText::new(message).color(egui::Color32::YELLOW),
             );
@@ -188,7 +180,11 @@ fn draw_config_page(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
 }
 
 fn text(language: &str, zh: &'static str, en: &'static str) -> &'static str {
-    if language == "zh-Hans" { zh } else { en }
+    if crate::ui::is_chinese(language) {
+        zh
+    } else {
+        en
+    }
 }
 
 fn draw_settings_content(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {

--- a/src/ui/toolbar.rs
+++ b/src/ui/toolbar.rs
@@ -18,19 +18,7 @@ pub fn draw_toolbar(ui: &mut egui::Ui, state: &mut CsgoInventoryEditor) {
 
         if let Some(message) = &state.status_message {
             ui.add_space(12.0);
-            let status_label = egui::Label::new(
-                egui::RichText::new(message)
-                    .color(egui::Color32::LIGHT_RED)
-                    .size(13.0),
-            )
-            .truncate();
-            ui.add_sized(
-                egui::vec2(
-                    ui.available_width(),
-                    ui.text_style_height(&egui::TextStyle::Body),
-                ),
-                status_label,
-            );
+            crate::ui::draw_status_message(ui, message);
         }
     });
     ui.add_space(4.0);


### PR DESCRIPTION
## Summary
- Removed dead code: unused functions, struct fields, and `pub use` re-exports that were never referenced anywhere in the crate (verified by grep across `src/`).
- Stripped ~22 leftover `println!` debug log statements from `app.rs` and `online_data/api.rs` (kept genuine `eprintln!` error logging).
- Deduplicated parsing/serialization logic in the `inventory` module (shared escape decoding, string accessor, field-order sorting, and the six near-identical `create_*_select_list` methods).
- Deduplicated `online_data` provider select-list construction and collapsed redundant `Online` arms that ignored `data`.
- Shared the exe-relative editor data directory path between `api.rs` and `settings.rs`.
- Removed the redundant `value` field from `SelectWindowItem` (it always duplicated the `id`).
- Extracted shared `ui::helpers` (`draw_named_combo`, `draw_status_message`, `is_chinese`, `rcon_readonly_message`) to remove four duplicated ComboBox blocks, the RCON read-only banner, and the red status-message rendering.

## Notes
- Per decision, serialization round-trip-only fields (`Item.in_use`, `DefaultEquip`/`default_equips`, `config` `rarity_weights`) were intentionally kept to preserve `inventory.txt`/`config.txt` fidelity.
- `cargo clippy -- -D warnings` and `cargo build` pass.

## Test plan
- [x] `cargo clippy -- -D warnings`
- [x] `cargo build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared UI helpers for status messages, language detection, and named combo controls to improve consistency across the app.
  * Improved Chinese-language labeling across settings, inventory, item details, and RCON views.
  * Moved settings and online cache files to the editor directory.
* **Bug Fixes**
  * Fixed escaped-character handling when reading language/inventory data.
  * Simplified online-data loading and reduced unnecessary diagnostic output.
  * Updated selection lists and filtering for more consistent item display and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->